### PR TITLE
dts: st: pinctrl.dtsi files including DCMI pins

### DIFF
--- a/dts/st/f2/stm32f207i(c-e-f-g)hx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207i(c-e-f-g)hx-pinctrl.dtsi
@@ -834,6 +834,148 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f2/stm32f207i(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207i(c-e-f-g)tx-pinctrl.dtsi
@@ -834,6 +834,148 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f2/stm32f207v(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207v(c-e-f-g)tx-pinctrl.dtsi
@@ -561,6 +561,98 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f2/stm32f207z(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207z(c-e-f-g)tx-pinctrl.dtsi
@@ -721,6 +721,98 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f2/stm32f217i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217i(e-g)hx-pinctrl.dtsi
@@ -834,6 +834,148 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f2/stm32f217i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217i(e-g)tx-pinctrl.dtsi
@@ -834,6 +834,148 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f2/stm32f217v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217v(e-g)tx-pinctrl.dtsi
@@ -561,6 +561,98 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f2/stm32f217z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217z(e-g)tx-pinctrl.dtsi
@@ -721,6 +721,98 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f407i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407i(e-g)hx-pinctrl.dtsi
@@ -834,6 +834,148 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f407i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407i(e-g)tx-pinctrl.dtsi
@@ -834,6 +834,148 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f407v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407v(e-g)tx-pinctrl.dtsi
@@ -561,6 +561,98 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f407z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407z(e-g)tx-pinctrl.dtsi
@@ -721,6 +721,98 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f417i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417i(e-g)hx-pinctrl.dtsi
@@ -834,6 +834,148 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f417i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417i(e-g)tx-pinctrl.dtsi
@@ -834,6 +834,148 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f417v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417v(e-g)tx-pinctrl.dtsi
@@ -561,6 +561,98 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f417z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417z(e-g)tx-pinctrl.dtsi
@@ -721,6 +721,98 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f427a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427a(g-i)hx-pinctrl.dtsi
@@ -778,6 +778,163 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f427i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427i(g-i)hx-pinctrl.dtsi
@@ -834,6 +834,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f427i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427i(g-i)tx-pinctrl.dtsi
@@ -834,6 +834,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f427v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427v(g-i)tx-pinctrl.dtsi
@@ -561,6 +561,103 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f427z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427z(g-i)tx-pinctrl.dtsi
@@ -721,6 +721,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f429a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429a(g-i)hx-pinctrl.dtsi
@@ -778,6 +778,163 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f429b(e-g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429b(e-g-i)tx-pinctrl.dtsi
@@ -946,6 +946,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f429i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429i(e-g)tx-pinctrl.dtsi
@@ -834,6 +834,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f429i(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429i(e-g-i)hx-pinctrl.dtsi
@@ -834,6 +834,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f429iitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429iitx-pinctrl.dtsi
@@ -834,6 +834,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f429n(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429n(e-g)hx-pinctrl.dtsi
@@ -946,6 +946,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f429nihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429nihx-pinctrl.dtsi
@@ -946,6 +946,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f429v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429v(e-g)tx-pinctrl.dtsi
@@ -561,6 +561,103 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f429vitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429vitx-pinctrl.dtsi
@@ -561,6 +561,103 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f429z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429z(e-g)tx-pinctrl.dtsi
@@ -721,6 +721,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f429zgyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429zgyx-pinctrl.dtsi
@@ -721,6 +721,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f429zitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429zitx-pinctrl.dtsi
@@ -721,6 +721,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f429ziyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429ziyx-pinctrl.dtsi
@@ -721,6 +721,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f437aihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437aihx-pinctrl.dtsi
@@ -778,6 +778,163 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f437i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437i(g-i)hx-pinctrl.dtsi
@@ -834,6 +834,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f437i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437i(g-i)tx-pinctrl.dtsi
@@ -834,6 +834,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f437v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437v(g-i)tx-pinctrl.dtsi
@@ -561,6 +561,103 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f437z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437z(g-i)tx-pinctrl.dtsi
@@ -721,6 +721,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f439aihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439aihx-pinctrl.dtsi
@@ -778,6 +778,163 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f439b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439b(g-i)tx-pinctrl.dtsi
@@ -946,6 +946,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f439i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439i(g-i)hx-pinctrl.dtsi
@@ -834,6 +834,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f439i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439i(g-i)tx-pinctrl.dtsi
@@ -834,6 +834,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f439n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439n(g-i)hx-pinctrl.dtsi
@@ -946,6 +946,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f439v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439v(g-i)tx-pinctrl.dtsi
@@ -561,6 +561,103 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f439z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439z(g-i)tx-pinctrl.dtsi
@@ -721,6 +721,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f439z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439z(g-i)yx-pinctrl.dtsi
@@ -721,6 +721,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f446m(c-e)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446m(c-e)yx-pinctrl.dtsi
@@ -465,6 +465,78 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f446r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446r(c-e)tx-pinctrl.dtsi
@@ -424,6 +424,73 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f446v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446v(c-e)tx-pinctrl.dtsi
@@ -557,6 +557,103 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_sdnwe_pa7: fmc_sdnwe_pa7 {

--- a/dts/st/f4/stm32f446z(c-e)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)hx-pinctrl.dtsi
@@ -721,6 +721,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_sdnwe_pa7: fmc_sdnwe_pa7 {

--- a/dts/st/f4/stm32f446z(c-e)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)jx-pinctrl.dtsi
@@ -721,6 +721,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_sdnwe_pa7: fmc_sdnwe_pa7 {

--- a/dts/st/f4/stm32f446z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)tx-pinctrl.dtsi
@@ -721,6 +721,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_sdnwe_pa7: fmc_sdnwe_pa7 {

--- a/dts/st/f4/stm32f469a(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469a(e-g-i)hx-pinctrl.dtsi
@@ -730,6 +730,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_sdnwe_pa7: fmc_sdnwe_pa7 {

--- a/dts/st/f4/stm32f469a(e-g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469a(e-g-i)yx-pinctrl.dtsi
@@ -730,6 +730,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_sdnwe_pa7: fmc_sdnwe_pa7 {

--- a/dts/st/f4/stm32f469b(e-g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469b(e-g-i)tx-pinctrl.dtsi
@@ -910,6 +910,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f469i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469i(e-g)tx-pinctrl.dtsi
@@ -794,6 +794,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f469i(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469i(e-g-i)hx-pinctrl.dtsi
@@ -794,6 +794,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f469iitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469iitx-pinctrl.dtsi
@@ -794,6 +794,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f469n(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469n(e-g)hx-pinctrl.dtsi
@@ -910,6 +910,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f469nihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469nihx-pinctrl.dtsi
@@ -910,6 +910,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f469v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469v(e-g)tx-pinctrl.dtsi
@@ -501,6 +501,78 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_sdnwe_pa7: fmc_sdnwe_pa7 {

--- a/dts/st/f4/stm32f469vitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469vitx-pinctrl.dtsi
@@ -501,6 +501,78 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_sdnwe_pa7: fmc_sdnwe_pa7 {

--- a/dts/st/f4/stm32f469z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469z(e-g)tx-pinctrl.dtsi
@@ -673,6 +673,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_sdnwe_pa7: fmc_sdnwe_pa7 {

--- a/dts/st/f4/stm32f469zitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469zitx-pinctrl.dtsi
@@ -673,6 +673,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_sdnwe_pa7: fmc_sdnwe_pa7 {

--- a/dts/st/f4/stm32f479a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479a(g-i)hx-pinctrl.dtsi
@@ -730,6 +730,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_sdnwe_pa7: fmc_sdnwe_pa7 {

--- a/dts/st/f4/stm32f479a(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479a(g-i)yx-pinctrl.dtsi
@@ -730,6 +730,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_sdnwe_pa7: fmc_sdnwe_pa7 {

--- a/dts/st/f4/stm32f479b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479b(g-i)tx-pinctrl.dtsi
@@ -910,6 +910,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f479i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479i(g-i)hx-pinctrl.dtsi
@@ -794,6 +794,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f479i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479i(g-i)tx-pinctrl.dtsi
@@ -794,6 +794,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f479n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479n(g-i)hx-pinctrl.dtsi
@@ -910,6 +910,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f4/stm32f479v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479v(g-i)tx-pinctrl.dtsi
@@ -501,6 +501,78 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_sdnwe_pa7: fmc_sdnwe_pa7 {

--- a/dts/st/f4/stm32f479z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479z(g-i)tx-pinctrl.dtsi
@@ -673,6 +673,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_sdnwe_pa7: fmc_sdnwe_pa7 {

--- a/dts/st/f7/stm32f745i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745i(e-g)kx-pinctrl.dtsi
@@ -834,6 +834,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f745i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745i(e-g)tx-pinctrl.dtsi
@@ -834,6 +834,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f745v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745v(e-g)hx-pinctrl.dtsi
@@ -561,6 +561,103 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f745v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745v(e-g)tx-pinctrl.dtsi
@@ -561,6 +561,103 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f745z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745z(e-g)tx-pinctrl.dtsi
@@ -721,6 +721,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
@@ -946,6 +946,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
@@ -834,6 +834,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f746ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746ietx-pinctrl.dtsi
@@ -834,6 +834,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f746igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746igtx-pinctrl.dtsi
@@ -834,6 +834,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f746nehx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nehx-pinctrl.dtsi
@@ -946,6 +946,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f746nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nghx-pinctrl.dtsi
@@ -946,6 +946,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f746v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746v(e-g)hx-pinctrl.dtsi
@@ -561,6 +561,103 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f746vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746vetx-pinctrl.dtsi
@@ -561,6 +561,103 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f746vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746vgtx-pinctrl.dtsi
@@ -561,6 +561,103 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
@@ -721,6 +721,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f746zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zetx-pinctrl.dtsi
@@ -721,6 +721,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
@@ -721,6 +721,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
@@ -946,6 +946,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f750v8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750v8tx-pinctrl.dtsi
@@ -561,6 +561,103 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
@@ -721,6 +721,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
@@ -946,6 +946,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f756igkx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igkx-pinctrl.dtsi
@@ -834,6 +834,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f756igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igtx-pinctrl.dtsi
@@ -834,6 +834,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f756nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756nghx-pinctrl.dtsi
@@ -946,6 +946,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f756vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756vghx-pinctrl.dtsi
@@ -561,6 +561,103 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f756vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756vgtx-pinctrl.dtsi
@@ -561,6 +561,103 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
@@ -721,6 +721,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
@@ -721,6 +721,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
@@ -969,6 +969,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
@@ -857,6 +857,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
@@ -857,6 +857,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
@@ -969,6 +969,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f765v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765v(g-i)hx-pinctrl.dtsi
@@ -579,6 +579,103 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f765v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765v(g-i)tx-pinctrl.dtsi
@@ -579,6 +579,103 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
@@ -739,6 +739,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
@@ -969,6 +969,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
@@ -857,6 +857,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
@@ -857,6 +857,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
@@ -969,6 +969,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f767vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vghx-pinctrl.dtsi
@@ -579,6 +579,103 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
@@ -579,6 +579,103 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f767vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vihx-pinctrl.dtsi
@@ -579,6 +579,103 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f767vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vitx-pinctrl.dtsi
@@ -579,6 +579,103 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
@@ -739,6 +739,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f767zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zitx-pinctrl.dtsi
@@ -739,6 +739,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
@@ -753,6 +753,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_sdnwe_pa7: fmc_sdnwe_pa7 {

--- a/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
@@ -753,6 +753,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_sdnwe_pa7: fmc_sdnwe_pa7 {

--- a/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
@@ -933,6 +933,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f769igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769igtx-pinctrl.dtsi
@@ -812,6 +812,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f769iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769iitx-pinctrl.dtsi
@@ -812,6 +812,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f769nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nghx-pinctrl.dtsi
@@ -933,6 +933,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f769nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nihx-pinctrl.dtsi
@@ -933,6 +933,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f777bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777bitx-pinctrl.dtsi
@@ -969,6 +969,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f777iikx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iikx-pinctrl.dtsi
@@ -857,6 +857,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f777iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iitx-pinctrl.dtsi
@@ -857,6 +857,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f777nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777nihx-pinctrl.dtsi
@@ -969,6 +969,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f777vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vihx-pinctrl.dtsi
@@ -579,6 +579,103 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f777vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vitx-pinctrl.dtsi
@@ -579,6 +579,103 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f777zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777zitx-pinctrl.dtsi
@@ -739,6 +739,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
@@ -753,6 +753,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_sdnwe_pa7: fmc_sdnwe_pa7 {

--- a/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
@@ -753,6 +753,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_sdnwe_pa7: fmc_sdnwe_pa7 {

--- a/dts/st/f7/stm32f779bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779bitx-pinctrl.dtsi
@@ -933,6 +933,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f779iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779iitx-pinctrl.dtsi
@@ -812,6 +812,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f779nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779nihx-pinctrl.dtsi
@@ -933,6 +933,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h5/stm32h562agix-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562agix-pinctrl.dtsi
@@ -784,6 +784,183 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe2: dcmi_d3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph13: dcmi_d3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h5/stm32h562aiix-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562aiix-pinctrl.dtsi
@@ -784,6 +784,183 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe2: dcmi_d3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph13: dcmi_d3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h5/stm32h562igkx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562igkx-pinctrl.dtsi
@@ -800,6 +800,193 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe2: dcmi_d3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph13: dcmi_d3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h5/stm32h562igtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562igtx-pinctrl.dtsi
@@ -800,6 +800,193 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe2: dcmi_d3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph13: dcmi_d3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h5/stm32h562iikx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562iikx-pinctrl.dtsi
@@ -800,6 +800,193 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe2: dcmi_d3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph13: dcmi_d3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h5/stm32h562iitx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562iitx-pinctrl.dtsi
@@ -800,6 +800,193 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe2: dcmi_d3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph13: dcmi_d3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h5/stm32h562rgtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562rgtx-pinctrl.dtsi
@@ -412,6 +412,83 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h5/stm32h562rgvx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562rgvx-pinctrl.dtsi
@@ -428,6 +428,93 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h5/stm32h562ritx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562ritx-pinctrl.dtsi
@@ -412,6 +412,83 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h5/stm32h562rivx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562rivx-pinctrl.dtsi
@@ -428,6 +428,93 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h5/stm32h562vgtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562vgtx-pinctrl.dtsi
@@ -536,6 +536,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe2: dcmi_d3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h5/stm32h562vitx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562vitx-pinctrl.dtsi
@@ -536,6 +536,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe2: dcmi_d3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h5/stm32h562zgtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562zgtx-pinctrl.dtsi
@@ -688,6 +688,133 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe2: dcmi_d3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h5/stm32h562zitx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562zitx-pinctrl.dtsi
@@ -688,6 +688,133 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe2: dcmi_d3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h5/stm32h563agix-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563agix-pinctrl.dtsi
@@ -784,6 +784,183 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe2: dcmi_d3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph13: dcmi_d3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h5/stm32h563aiix-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563aiix-pinctrl.dtsi
@@ -784,6 +784,183 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe2: dcmi_d3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph13: dcmi_d3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h5/stm32h563aiixq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563aiixq-pinctrl.dtsi
@@ -776,6 +776,188 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe2: dcmi_d3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph13: dcmi_d3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h5/stm32h563igkx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563igkx-pinctrl.dtsi
@@ -800,6 +800,193 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe2: dcmi_d3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph13: dcmi_d3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h5/stm32h563igtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563igtx-pinctrl.dtsi
@@ -800,6 +800,193 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe2: dcmi_d3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph13: dcmi_d3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h5/stm32h563iikx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563iikx-pinctrl.dtsi
@@ -800,6 +800,193 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe2: dcmi_d3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph13: dcmi_d3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h5/stm32h563iikxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563iikxq-pinctrl.dtsi
@@ -796,6 +796,193 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe2: dcmi_d3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph13: dcmi_d3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h5/stm32h563iitx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563iitx-pinctrl.dtsi
@@ -800,6 +800,193 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe2: dcmi_d3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph13: dcmi_d3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h5/stm32h563iitxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563iitxq-pinctrl.dtsi
@@ -784,6 +784,188 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe2: dcmi_d3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph13: dcmi_d3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h5/stm32h563miyxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563miyxq-pinctrl.dtsi
@@ -444,6 +444,83 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h5/stm32h563rgtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563rgtx-pinctrl.dtsi
@@ -412,6 +412,83 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h5/stm32h563rgvx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563rgvx-pinctrl.dtsi
@@ -428,6 +428,93 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h5/stm32h563ritx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563ritx-pinctrl.dtsi
@@ -412,6 +412,83 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h5/stm32h563rivx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563rivx-pinctrl.dtsi
@@ -428,6 +428,93 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h5/stm32h563vgtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563vgtx-pinctrl.dtsi
@@ -536,6 +536,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe2: dcmi_d3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h5/stm32h563vitx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563vitx-pinctrl.dtsi
@@ -536,6 +536,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe2: dcmi_d3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h5/stm32h563vitxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563vitxq-pinctrl.dtsi
@@ -504,6 +504,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe2: dcmi_d3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h5/stm32h563zgtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563zgtx-pinctrl.dtsi
@@ -688,6 +688,133 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe2: dcmi_d3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h5/stm32h563zitx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563zitx-pinctrl.dtsi
@@ -688,6 +688,133 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe2: dcmi_d3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h5/stm32h563zitxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563zitxq-pinctrl.dtsi
@@ -656,6 +656,133 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe2: dcmi_d3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h5/stm32h573aiix-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573aiix-pinctrl.dtsi
@@ -784,6 +784,183 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe2: dcmi_d3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph13: dcmi_d3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h5/stm32h573aiixq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573aiixq-pinctrl.dtsi
@@ -776,6 +776,188 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe2: dcmi_d3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph13: dcmi_d3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h5/stm32h573iikx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573iikx-pinctrl.dtsi
@@ -800,6 +800,193 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe2: dcmi_d3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph13: dcmi_d3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h5/stm32h573iikxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573iikxq-pinctrl.dtsi
@@ -796,6 +796,193 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe2: dcmi_d3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph13: dcmi_d3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h5/stm32h573iitx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573iitx-pinctrl.dtsi
@@ -800,6 +800,193 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe2: dcmi_d3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph13: dcmi_d3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h5/stm32h573iitxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573iitxq-pinctrl.dtsi
@@ -784,6 +784,188 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe2: dcmi_d3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph13: dcmi_d3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h5/stm32h573miyxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573miyxq-pinctrl.dtsi
@@ -444,6 +444,83 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h5/stm32h573ritx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573ritx-pinctrl.dtsi
@@ -412,6 +412,83 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h5/stm32h573rivx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573rivx-pinctrl.dtsi
@@ -428,6 +428,93 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h5/stm32h573vitx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573vitx-pinctrl.dtsi
@@ -536,6 +536,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe2: dcmi_d3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h5/stm32h573vitxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573vitxq-pinctrl.dtsi
@@ -504,6 +504,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe2: dcmi_d3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h5/stm32h573zitx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573zitx-pinctrl.dtsi
@@ -688,6 +688,133 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe2: dcmi_d3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h5/stm32h573zitxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573zitxq-pinctrl.dtsi
@@ -656,6 +656,133 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pa8: dcmi_d3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb4: dcmi_d7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb15: dcmi_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe2: dcmi_d3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h723vehx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vehx-pinctrl.dtsi
@@ -524,6 +524,108 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h723vetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vetx-pinctrl.dtsi
@@ -524,6 +524,108 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h723vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vghx-pinctrl.dtsi
@@ -524,6 +524,108 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h723vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vgtx-pinctrl.dtsi
@@ -524,6 +524,108 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h723zeix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zeix-pinctrl.dtsi
@@ -752,6 +752,123 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h723zetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zetx-pinctrl.dtsi
@@ -724,6 +724,123 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h723zgix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zgix-pinctrl.dtsi
@@ -752,6 +752,123 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h723zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zgtx-pinctrl.dtsi
@@ -724,6 +724,123 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h725aeix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725aeix-pinctrl.dtsi
@@ -844,6 +844,143 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h725agix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725agix-pinctrl.dtsi
@@ -844,6 +844,143 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h725iekx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725iekx-pinctrl.dtsi
@@ -888,6 +888,153 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h725ietx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725ietx-pinctrl.dtsi
@@ -752,6 +752,123 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h725igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725igkx-pinctrl.dtsi
@@ -888,6 +888,153 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h725igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725igtx-pinctrl.dtsi
@@ -752,6 +752,123 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h725revx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725revx-pinctrl.dtsi
@@ -368,6 +368,73 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h725rgvx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725rgvx-pinctrl.dtsi
@@ -368,6 +368,73 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h725vehx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vehx-pinctrl.dtsi
@@ -504,6 +504,108 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h725vetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vetx-pinctrl.dtsi
@@ -472,6 +472,93 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h725vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vghx-pinctrl.dtsi
@@ -504,6 +504,108 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h725vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vgtx-pinctrl.dtsi
@@ -472,6 +472,93 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h725vgyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vgyx-pinctrl.dtsi
@@ -452,6 +452,93 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h725zetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725zetx-pinctrl.dtsi
@@ -636,6 +636,123 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h725zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725zgtx-pinctrl.dtsi
@@ -636,6 +636,123 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h730abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730abixq-pinctrl.dtsi
@@ -844,6 +844,143 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h730ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730ibkxq-pinctrl.dtsi
@@ -888,6 +888,153 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h730ibtxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730ibtxq-pinctrl.dtsi
@@ -752,6 +752,123 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h730vbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730vbhx-pinctrl.dtsi
@@ -524,6 +524,108 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h730vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730vbtx-pinctrl.dtsi
@@ -524,6 +524,108 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h730zbix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730zbix-pinctrl.dtsi
@@ -752,6 +752,123 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h730zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730zbtx-pinctrl.dtsi
@@ -724,6 +724,123 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h733vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733vghx-pinctrl.dtsi
@@ -524,6 +524,108 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h733vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733vgtx-pinctrl.dtsi
@@ -524,6 +524,108 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h733zgix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733zgix-pinctrl.dtsi
@@ -752,6 +752,123 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h733zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733zgtx-pinctrl.dtsi
@@ -724,6 +724,123 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h735agix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735agix-pinctrl.dtsi
@@ -844,6 +844,143 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h735igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735igkx-pinctrl.dtsi
@@ -888,6 +888,153 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h735igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735igtx-pinctrl.dtsi
@@ -752,6 +752,123 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h735rgvx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735rgvx-pinctrl.dtsi
@@ -368,6 +368,73 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h735vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vghx-pinctrl.dtsi
@@ -504,6 +504,108 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h735vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vgtx-pinctrl.dtsi
@@ -472,6 +472,93 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h735vgyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vgyx-pinctrl.dtsi
@@ -452,6 +452,93 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h735zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735zgtx-pinctrl.dtsi
@@ -636,6 +636,123 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
@@ -824,6 +824,143 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
@@ -968,6 +968,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
@@ -856,6 +856,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
@@ -856,6 +856,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
@@ -524,6 +524,103 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
@@ -524,6 +524,103 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
@@ -1048,6 +1048,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
@@ -724,6 +724,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
@@ -824,6 +824,143 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
@@ -968,6 +968,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h743bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bitx-pinctrl.dtsi
@@ -968,6 +968,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h743igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igkx-pinctrl.dtsi
@@ -856,6 +856,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h743igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igtx-pinctrl.dtsi
@@ -856,6 +856,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h743iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iikx-pinctrl.dtsi
@@ -856,6 +856,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h743iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iitx-pinctrl.dtsi
@@ -856,6 +856,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
@@ -524,6 +524,103 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
@@ -524,6 +524,103 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h743vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vitx-pinctrl.dtsi
@@ -524,6 +524,103 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h743xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xghx-pinctrl.dtsi
@@ -1048,6 +1048,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h743xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xihx-pinctrl.dtsi
@@ -1048,6 +1048,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
@@ -724,6 +724,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h743zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zitx-pinctrl.dtsi
@@ -724,6 +724,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
@@ -896,6 +896,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h745bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bitx-pinctrl.dtsi
@@ -896,6 +896,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h745igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igkx-pinctrl.dtsi
@@ -888,6 +888,148 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h745igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igtx-pinctrl.dtsi
@@ -752,6 +752,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h745iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iikx-pinctrl.dtsi
@@ -888,6 +888,148 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h745iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iitx-pinctrl.dtsi
@@ -752,6 +752,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h745xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xghx-pinctrl.dtsi
@@ -1048,6 +1048,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h745xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xihx-pinctrl.dtsi
@@ -1048,6 +1048,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
@@ -632,6 +632,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h745zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zitx-pinctrl.dtsi
@@ -632,6 +632,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
@@ -724,6 +724,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
@@ -860,6 +860,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h747bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bitx-pinctrl.dtsi
@@ -860,6 +860,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h747igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747igtx-pinctrl.dtsi
@@ -724,6 +724,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h747iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747iitx-pinctrl.dtsi
@@ -724,6 +724,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h747xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xghx-pinctrl.dtsi
@@ -1048,6 +1048,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h747xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xihx-pinctrl.dtsi
@@ -1048,6 +1048,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
@@ -640,6 +640,103 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
@@ -856,6 +856,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
@@ -856,6 +856,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
@@ -524,6 +524,103 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
@@ -1048,6 +1048,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
@@ -724,6 +724,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h753aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753aiix-pinctrl.dtsi
@@ -824,6 +824,143 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h753bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753bitx-pinctrl.dtsi
@@ -968,6 +968,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h753iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iikx-pinctrl.dtsi
@@ -856,6 +856,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h753iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iitx-pinctrl.dtsi
@@ -856,6 +856,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h753vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vihx-pinctrl.dtsi
@@ -524,6 +524,103 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h753vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vitx-pinctrl.dtsi
@@ -524,6 +524,103 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h753xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753xihx-pinctrl.dtsi
@@ -1048,6 +1048,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h753zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753zitx-pinctrl.dtsi
@@ -724,6 +724,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h755bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755bitx-pinctrl.dtsi
@@ -896,6 +896,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h755iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iikx-pinctrl.dtsi
@@ -888,6 +888,148 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h755iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iitx-pinctrl.dtsi
@@ -752,6 +752,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h755xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755xihx-pinctrl.dtsi
@@ -1048,6 +1048,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h755zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755zitx-pinctrl.dtsi
@@ -632,6 +632,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h757aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757aiix-pinctrl.dtsi
@@ -724,6 +724,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h757bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757bitx-pinctrl.dtsi
@@ -860,6 +860,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h757iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757iitx-pinctrl.dtsi
@@ -724,6 +724,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h757xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757xihx-pinctrl.dtsi
@@ -1048,6 +1048,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
@@ -640,6 +640,103 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
@@ -736,6 +736,143 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
@@ -752,6 +752,173 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
@@ -764,6 +764,153 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
@@ -752,6 +752,173 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
@@ -676,6 +676,123 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
@@ -924,6 +924,173 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
@@ -864,6 +864,173 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7a3qiyxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3qiyxq-pinctrl.dtsi
@@ -544,6 +544,118 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7a3r(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3r(g-i)tx-pinctrl.dtsi
@@ -384,6 +384,73 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
@@ -496,6 +496,108 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
@@ -476,6 +476,108 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
@@ -496,6 +496,108 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
@@ -448,6 +448,98 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
@@ -648,6 +648,123 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
@@ -576,6 +576,123 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
@@ -736,6 +736,143 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
@@ -764,6 +764,153 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
@@ -752,6 +752,173 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b0rbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0rbtx-pinctrl.dtsi
@@ -384,6 +384,73 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
@@ -496,6 +496,108 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
@@ -648,6 +648,123 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
@@ -736,6 +736,143 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
@@ -752,6 +752,173 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
@@ -764,6 +764,153 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
@@ -752,6 +752,173 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
@@ -676,6 +676,123 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
@@ -924,6 +924,173 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
@@ -864,6 +864,173 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b3qiyxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3qiyxq-pinctrl.dtsi
@@ -544,6 +544,118 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b3ritx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3ritx-pinctrl.dtsi
@@ -384,6 +384,73 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
@@ -496,6 +496,108 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
@@ -476,6 +476,108 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
@@ -496,6 +496,108 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
@@ -448,6 +448,98 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
@@ -648,6 +648,123 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
@@ -576,6 +576,123 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pb13: dcmi_d2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/l4/stm32l496a(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496a(e-g)ix-pinctrl.dtsi
@@ -786,6 +786,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_ph5: dcmi_pixclk_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l496agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496agixp-pinctrl.dtsi
@@ -778,6 +778,163 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_ph5: dcmi_pixclk_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l496q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496q(e-g)ix-pinctrl.dtsi
@@ -669,6 +669,113 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l496qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496qgixp-pinctrl.dtsi
@@ -661,6 +661,113 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l496qgixs-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496qgixs-pinctrl.dtsi
@@ -669,6 +669,113 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l496r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496r(e-g)tx-pinctrl.dtsi
@@ -416,6 +416,73 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l496rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496rgtxp-pinctrl.dtsi
@@ -400,6 +400,73 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l496v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496v(e-g)tx-pinctrl.dtsi
@@ -549,6 +549,113 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l496vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgtxp-pinctrl.dtsi
@@ -541,6 +541,108 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l496vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgyx-pinctrl.dtsi
@@ -541,6 +541,98 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l496vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgyxp-pinctrl.dtsi
@@ -529,6 +529,98 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l496wgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496wgyxp-pinctrl.dtsi
@@ -572,6 +572,93 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l496z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496z(e-g)tx-pinctrl.dtsi
@@ -709,6 +709,113 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l496zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496zgtxp-pinctrl.dtsi
@@ -701,6 +701,113 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4a6agix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6agix-pinctrl.dtsi
@@ -786,6 +786,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_ph5: dcmi_pixclk_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4a6agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6agixp-pinctrl.dtsi
@@ -778,6 +778,163 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_ph5: dcmi_pixclk_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4a6qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6qgix-pinctrl.dtsi
@@ -669,6 +669,113 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4a6qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6qgixp-pinctrl.dtsi
@@ -661,6 +661,113 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4a6rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6rgtx-pinctrl.dtsi
@@ -416,6 +416,73 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4a6rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6rgtxp-pinctrl.dtsi
@@ -400,6 +400,73 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4a6vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgtx-pinctrl.dtsi
@@ -549,6 +549,113 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4a6vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgtxp-pinctrl.dtsi
@@ -541,6 +541,108 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4a6vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgyx-pinctrl.dtsi
@@ -541,6 +541,98 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4a6vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgyxp-pinctrl.dtsi
@@ -529,6 +529,98 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4a6zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6zgtx-pinctrl.dtsi
@@ -709,6 +709,113 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4a6zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6zgtxp-pinctrl.dtsi
@@ -701,6 +701,113 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4p5a(g-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5a(g-e)ix-pinctrl.dtsi
@@ -736,6 +736,178 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pc10: dcmi_vsync_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_ph5: dcmi_pixclk_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4p5agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5agixp-pinctrl.dtsi
@@ -728,6 +728,173 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pc10: dcmi_vsync_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_ph5: dcmi_pixclk_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4p5q(g-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5q(g-e)ix-pinctrl.dtsi
@@ -623,6 +623,123 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pc10: dcmi_vsync_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4p5qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5qgixp-pinctrl.dtsi
@@ -615,6 +615,123 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pc10: dcmi_vsync_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4p5qgixs-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5qgixs-pinctrl.dtsi
@@ -615,6 +615,123 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pc10: dcmi_vsync_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4p5r(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5r(g-e)tx-pinctrl.dtsi
@@ -382,6 +382,83 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pc10: dcmi_vsync_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4p5rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5rgtxp-pinctrl.dtsi
@@ -366,6 +366,83 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pc10: dcmi_vsync_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4p5v(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5v(g-e)tx-pinctrl.dtsi
@@ -515,6 +515,123 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pc10: dcmi_vsync_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4p5v(g-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5v(g-e)yx-pinctrl.dtsi
@@ -507,6 +507,108 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pc10: dcmi_vsync_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4p5vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5vgtxp-pinctrl.dtsi
@@ -507,6 +507,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pc10: dcmi_vsync_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4p5vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5vgyxp-pinctrl.dtsi
@@ -495,6 +495,108 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pc10: dcmi_vsync_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4p5z(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5z(g-e)tx-pinctrl.dtsi
@@ -643,6 +643,123 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pc10: dcmi_vsync_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4p5zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5zgtxp-pinctrl.dtsi
@@ -635,6 +635,123 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pc10: dcmi_vsync_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4q5agix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5agix-pinctrl.dtsi
@@ -736,6 +736,178 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pc10: dcmi_vsync_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_ph5: dcmi_pixclk_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4q5agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5agixp-pinctrl.dtsi
@@ -728,6 +728,173 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pc10: dcmi_vsync_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_ph5: dcmi_pixclk_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4q5qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5qgix-pinctrl.dtsi
@@ -623,6 +623,123 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pc10: dcmi_vsync_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4q5qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5qgixp-pinctrl.dtsi
@@ -615,6 +615,123 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pc10: dcmi_vsync_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4q5rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5rgtx-pinctrl.dtsi
@@ -382,6 +382,83 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pc10: dcmi_vsync_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4q5rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5rgtxp-pinctrl.dtsi
@@ -366,6 +366,83 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pc10: dcmi_vsync_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4q5vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgtx-pinctrl.dtsi
@@ -515,6 +515,123 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pc10: dcmi_vsync_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4q5vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgtxp-pinctrl.dtsi
@@ -507,6 +507,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pc10: dcmi_vsync_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4q5vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgyx-pinctrl.dtsi
@@ -507,6 +507,108 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pc10: dcmi_vsync_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4q5vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgyxp-pinctrl.dtsi
@@ -495,6 +495,108 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pc10: dcmi_vsync_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4q5zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5zgtx-pinctrl.dtsi
@@ -643,6 +643,123 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pc10: dcmi_vsync_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4q5zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5zgtxp-pinctrl.dtsi
@@ -635,6 +635,123 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pc10: dcmi_vsync_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4r5a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5a(g-i)ix-pinctrl.dtsi
@@ -672,6 +672,173 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_ph5: dcmi_pixclk_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4r5aiixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5aiixp-pinctrl.dtsi
@@ -672,6 +672,173 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_ph5: dcmi_pixclk_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4r5q(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5q(g-i)ix-pinctrl.dtsi
@@ -559,6 +559,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4r5qgixs-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5qgixs-pinctrl.dtsi
@@ -559,6 +559,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4r5qiixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5qiixp-pinctrl.dtsi
@@ -559,6 +559,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4r5v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5v(g-i)tx-pinctrl.dtsi
@@ -451,6 +451,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4r5z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5z(g-i)tx-pinctrl.dtsi
@@ -579,6 +579,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4r5z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5z(g-i)yx-pinctrl.dtsi
@@ -559,6 +559,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4r5zitxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5zitxp-pinctrl.dtsi
@@ -571,6 +571,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4r7aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7aiix-pinctrl.dtsi
@@ -672,6 +672,173 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_ph5: dcmi_pixclk_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4r7vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7vitx-pinctrl.dtsi
@@ -451,6 +451,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4r7zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7zitx-pinctrl.dtsi
@@ -579,6 +579,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4r9a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9a(g-i)ix-pinctrl.dtsi
@@ -648,6 +648,173 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_ph5: dcmi_pixclk_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4r9v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9v(g-i)tx-pinctrl.dtsi
@@ -423,6 +423,108 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4r9z(g-i)jx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)jx-pinctrl.dtsi
@@ -567,6 +567,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4r9z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)tx-pinctrl.dtsi
@@ -555,6 +555,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4r9z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)yx-pinctrl.dtsi
@@ -559,6 +559,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4r9ziyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9ziyxp-pinctrl.dtsi
@@ -551,6 +551,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4s5aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5aiix-pinctrl.dtsi
@@ -672,6 +672,173 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_ph5: dcmi_pixclk_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4s5qiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5qiix-pinctrl.dtsi
@@ -559,6 +559,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4s5vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5vitx-pinctrl.dtsi
@@ -451,6 +451,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4s5zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5zitx-pinctrl.dtsi
@@ -579,6 +579,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4s5ziyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5ziyx-pinctrl.dtsi
@@ -559,6 +559,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4s7aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7aiix-pinctrl.dtsi
@@ -672,6 +672,173 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_ph5: dcmi_pixclk_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4s7vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7vitx-pinctrl.dtsi
@@ -451,6 +451,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4s7zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7zitx-pinctrl.dtsi
@@ -579,6 +579,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4s9aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9aiix-pinctrl.dtsi
@@ -648,6 +648,173 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_ph5: dcmi_pixclk_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4s9vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9vitx-pinctrl.dtsi
@@ -423,6 +423,108 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4s9zijx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9zijx-pinctrl.dtsi
@@ -567,6 +567,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4s9zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9zitx-pinctrl.dtsi
@@ -555,6 +555,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4s9ziyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9ziyx-pinctrl.dtsi
@@ -559,6 +559,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aaax-pinctrl.dtsi
@@ -908,6 +908,188 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aabx-pinctrl.dtsi
@@ -576,6 +576,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aacx-pinctrl.dtsi
@@ -796,6 +796,188 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aadx-pinctrl.dtsi
@@ -576,6 +576,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151caax-pinctrl.dtsi
@@ -908,6 +908,188 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cabx-pinctrl.dtsi
@@ -576,6 +576,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cacx-pinctrl.dtsi
@@ -796,6 +796,188 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cadx-pinctrl.dtsi
@@ -576,6 +576,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151daax-pinctrl.dtsi
@@ -908,6 +908,188 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dabx-pinctrl.dtsi
@@ -576,6 +576,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dacx-pinctrl.dtsi
@@ -796,6 +796,188 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dadx-pinctrl.dtsi
@@ -576,6 +576,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151faax-pinctrl.dtsi
@@ -908,6 +908,188 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151fabx-pinctrl.dtsi
@@ -576,6 +576,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151facx-pinctrl.dtsi
@@ -796,6 +796,188 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151fadx-pinctrl.dtsi
@@ -576,6 +576,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp153aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aaax-pinctrl.dtsi
@@ -908,6 +908,188 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aabx-pinctrl.dtsi
@@ -576,6 +576,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aacx-pinctrl.dtsi
@@ -796,6 +796,188 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aadx-pinctrl.dtsi
@@ -576,6 +576,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153caax-pinctrl.dtsi
@@ -908,6 +908,188 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cabx-pinctrl.dtsi
@@ -576,6 +576,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cacx-pinctrl.dtsi
@@ -796,6 +796,188 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cadx-pinctrl.dtsi
@@ -576,6 +576,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153daax-pinctrl.dtsi
@@ -908,6 +908,188 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dabx-pinctrl.dtsi
@@ -576,6 +576,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dacx-pinctrl.dtsi
@@ -796,6 +796,188 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dadx-pinctrl.dtsi
@@ -576,6 +576,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153faax-pinctrl.dtsi
@@ -908,6 +908,188 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153fabx-pinctrl.dtsi
@@ -576,6 +576,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153facx-pinctrl.dtsi
@@ -796,6 +796,188 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153fadx-pinctrl.dtsi
@@ -576,6 +576,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aaax-pinctrl.dtsi
@@ -908,6 +908,188 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aabx-pinctrl.dtsi
@@ -576,6 +576,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aacx-pinctrl.dtsi
@@ -796,6 +796,188 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aadx-pinctrl.dtsi
@@ -576,6 +576,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157caax-pinctrl.dtsi
@@ -908,6 +908,188 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cabx-pinctrl.dtsi
@@ -576,6 +576,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cacx-pinctrl.dtsi
@@ -796,6 +796,188 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cadx-pinctrl.dtsi
@@ -576,6 +576,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157daax-pinctrl.dtsi
@@ -908,6 +908,188 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dabx-pinctrl.dtsi
@@ -576,6 +576,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dacx-pinctrl.dtsi
@@ -796,6 +796,188 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dadx-pinctrl.dtsi
@@ -576,6 +576,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157faax-pinctrl.dtsi
@@ -908,6 +908,188 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157fabx-pinctrl.dtsi
@@ -576,6 +576,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157facx-pinctrl.dtsi
@@ -796,6 +796,188 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157fadx-pinctrl.dtsi
@@ -576,6 +576,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pc2: dcmi_pixclk_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd9: dcmi_hsync_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe11: dcmi_d4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe13: dcmi_d6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pg9: dcmi_vsync_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pg10: dcmi_d2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pg11: dcmi_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u535vcix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535vcix-pinctrl.dtsi
@@ -480,6 +480,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u535vcixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535vcixq-pinctrl.dtsi
@@ -452,6 +452,113 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u535vctx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535vctx-pinctrl.dtsi
@@ -480,6 +480,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u535vctxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535vctxq-pinctrl.dtsi
@@ -452,6 +452,113 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u535veix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535veix-pinctrl.dtsi
@@ -480,6 +480,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u535veixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535veixq-pinctrl.dtsi
@@ -452,6 +452,113 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u535vetx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535vetx-pinctrl.dtsi
@@ -480,6 +480,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u535vetxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535vetxq-pinctrl.dtsi
@@ -452,6 +452,113 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u545veix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545veix-pinctrl.dtsi
@@ -480,6 +480,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u545veixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545veixq-pinctrl.dtsi
@@ -452,6 +452,113 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u545vetx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545vetx-pinctrl.dtsi
@@ -480,6 +480,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u545vetxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545vetxq-pinctrl.dtsi
@@ -452,6 +452,113 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u575agix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575agix-pinctrl.dtsi
@@ -712,6 +712,173 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_ph5: dcmi_pixclk_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u575agixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575agixq-pinctrl.dtsi
@@ -700,6 +700,173 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_ph5: dcmi_pixclk_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u575aiix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575aiix-pinctrl.dtsi
@@ -712,6 +712,173 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_ph5: dcmi_pixclk_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u575aiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575aiixq-pinctrl.dtsi
@@ -700,6 +700,173 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_ph5: dcmi_pixclk_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u575ogyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ogyxq-pinctrl.dtsi
@@ -408,6 +408,93 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u575oiyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575oiyxq-pinctrl.dtsi
@@ -408,6 +408,93 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u575qgix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575qgix-pinctrl.dtsi
@@ -608,6 +608,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u575qgixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575qgixq-pinctrl.dtsi
@@ -592,6 +592,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u575qiix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575qiix-pinctrl.dtsi
@@ -608,6 +608,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u575qiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575qiixq-pinctrl.dtsi
@@ -592,6 +592,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u575rgtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575rgtx-pinctrl.dtsi
@@ -344,6 +344,78 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u575ritx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ritx-pinctrl.dtsi
@@ -344,6 +344,78 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u575vgtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575vgtx-pinctrl.dtsi
@@ -480,6 +480,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u575vgtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575vgtxq-pinctrl.dtsi
@@ -452,6 +452,113 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u575vitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575vitx-pinctrl.dtsi
@@ -480,6 +480,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u575vitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575vitxq-pinctrl.dtsi
@@ -452,6 +452,113 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u575zgtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575zgtx-pinctrl.dtsi
@@ -624,6 +624,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u575zgtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575zgtxq-pinctrl.dtsi
@@ -596,6 +596,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u575zitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575zitx-pinctrl.dtsi
@@ -624,6 +624,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u575zitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575zitxq-pinctrl.dtsi
@@ -596,6 +596,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u585aiix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585aiix-pinctrl.dtsi
@@ -712,6 +712,173 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_ph5: dcmi_pixclk_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u585aiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585aiixq-pinctrl.dtsi
@@ -700,6 +700,173 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_ph5: dcmi_pixclk_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u585oiyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585oiyxq-pinctrl.dtsi
@@ -408,6 +408,93 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u585qiix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585qiix-pinctrl.dtsi
@@ -608,6 +608,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u585qiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585qiixq-pinctrl.dtsi
@@ -592,6 +592,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u585ritx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585ritx-pinctrl.dtsi
@@ -344,6 +344,78 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u585vitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585vitx-pinctrl.dtsi
@@ -480,6 +480,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u585vitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585vitxq-pinctrl.dtsi
@@ -452,6 +452,113 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u585zitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585zitx-pinctrl.dtsi
@@ -624,6 +624,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u585zitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585zitxq-pinctrl.dtsi
@@ -596,6 +596,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u595aihx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595aihx-pinctrl.dtsi
@@ -780,6 +780,173 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_ph5: dcmi_pixclk_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u595aihxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595aihxq-pinctrl.dtsi
@@ -768,6 +768,173 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_ph5: dcmi_pixclk_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u595ajhx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595ajhx-pinctrl.dtsi
@@ -780,6 +780,173 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_ph5: dcmi_pixclk_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u595ajhxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595ajhxq-pinctrl.dtsi
@@ -768,6 +768,173 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_ph5: dcmi_pixclk_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u595qiix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595qiix-pinctrl.dtsi
@@ -676,6 +676,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u595qiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595qiixq-pinctrl.dtsi
@@ -660,6 +660,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u595qjix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595qjix-pinctrl.dtsi
@@ -676,6 +676,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u595qjixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595qjixq-pinctrl.dtsi
@@ -660,6 +660,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u595ritx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595ritx-pinctrl.dtsi
@@ -412,6 +412,78 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u595rjtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595rjtx-pinctrl.dtsi
@@ -412,6 +412,78 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u595vitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595vitx-pinctrl.dtsi
@@ -548,6 +548,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u595vitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595vitxq-pinctrl.dtsi
@@ -512,6 +512,113 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u595vjtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595vjtx-pinctrl.dtsi
@@ -548,6 +548,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u595vjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595vjtxq-pinctrl.dtsi
@@ -512,6 +512,113 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u595zitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595zitx-pinctrl.dtsi
@@ -692,6 +692,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u595zitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595zitxq-pinctrl.dtsi
@@ -656,6 +656,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u595ziyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595ziyxq-pinctrl.dtsi
@@ -696,6 +696,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u595zjtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595zjtx-pinctrl.dtsi
@@ -692,6 +692,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u595zjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595zjtxq-pinctrl.dtsi
@@ -656,6 +656,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u595zjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595zjyxq-pinctrl.dtsi
@@ -696,6 +696,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u599bjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599bjyxq-pinctrl.dtsi
@@ -816,6 +816,173 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_ph5: dcmi_pixclk_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u599nihxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599nihxq-pinctrl.dtsi
@@ -860,6 +860,173 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_ph5: dcmi_pixclk_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u599njhxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599njhxq-pinctrl.dtsi
@@ -860,6 +860,173 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_ph5: dcmi_pixclk_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u599vitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599vitxq-pinctrl.dtsi
@@ -512,6 +512,113 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u599vjtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599vjtx-pinctrl.dtsi
@@ -548,6 +548,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u599vjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599vjtxq-pinctrl.dtsi
@@ -512,6 +512,113 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u599zitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599zitxq-pinctrl.dtsi
@@ -656,6 +656,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u599ziyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599ziyxq-pinctrl.dtsi
@@ -668,6 +668,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u599zjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599zjtxq-pinctrl.dtsi
@@ -656,6 +656,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u599zjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599zjyxq-pinctrl.dtsi
@@ -668,6 +668,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u5a5ajhx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5ajhx-pinctrl.dtsi
@@ -780,6 +780,173 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_ph5: dcmi_pixclk_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u5a5ajhxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5ajhxq-pinctrl.dtsi
@@ -768,6 +768,173 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_ph5: dcmi_pixclk_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u5a5qiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5qiixq-pinctrl.dtsi
@@ -660,6 +660,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u5a5qjix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5qjix-pinctrl.dtsi
@@ -676,6 +676,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u5a5qjixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5qjixq-pinctrl.dtsi
@@ -660,6 +660,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u5a5rjtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5rjtx-pinctrl.dtsi
@@ -412,6 +412,78 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u5a5vjtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5vjtx-pinctrl.dtsi
@@ -548,6 +548,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u5a5vjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5vjtxq-pinctrl.dtsi
@@ -512,6 +512,113 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u5a5zjtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5zjtx-pinctrl.dtsi
@@ -692,6 +692,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u5a5zjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5zjtxq-pinctrl.dtsi
@@ -656,6 +656,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u5a5zjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5zjyxq-pinctrl.dtsi
@@ -696,6 +696,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u5a9bjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a9bjyxq-pinctrl.dtsi
@@ -816,6 +816,173 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_ph5: dcmi_pixclk_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u5a9njhxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a9njhxq-pinctrl.dtsi
@@ -860,6 +860,173 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_ph5: dcmi_pixclk_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u5a9vjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a9vjtxq-pinctrl.dtsi
@@ -512,6 +512,113 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u5a9zjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a9zjtxq-pinctrl.dtsi
@@ -656,6 +656,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u5a9zjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a9zjyxq-pinctrl.dtsi
@@ -668,6 +668,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u5f7vitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f7vitx-pinctrl.dtsi
@@ -548,6 +548,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u5f7vitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f7vitxq-pinctrl.dtsi
@@ -512,6 +512,113 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u5f7vjtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f7vjtx-pinctrl.dtsi
@@ -548,6 +548,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u5f7vjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f7vjtxq-pinctrl.dtsi
@@ -512,6 +512,113 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u5f9bjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9bjyxq-pinctrl.dtsi
@@ -816,6 +816,173 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_ph5: dcmi_pixclk_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/u5/stm32u5f9njhxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9njhxq-pinctrl.dtsi
@@ -860,6 +860,173 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_ph5: dcmi_pixclk_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u5f9vitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9vitxq-pinctrl.dtsi
@@ -436,6 +436,88 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u5f9vjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9vjtxq-pinctrl.dtsi
@@ -436,6 +436,88 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u5f9zijxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9zijxq-pinctrl.dtsi
@@ -608,6 +608,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u5f9zitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9zitxq-pinctrl.dtsi
@@ -608,6 +608,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u5f9zjjxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9zjjxq-pinctrl.dtsi
@@ -608,6 +608,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u5f9zjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9zjtxq-pinctrl.dtsi
@@ -608,6 +608,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u5g7vjtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g7vjtx-pinctrl.dtsi
@@ -548,6 +548,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u5g7vjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g7vjtxq-pinctrl.dtsi
@@ -512,6 +512,113 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u5g9bjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g9bjyxq-pinctrl.dtsi
@@ -816,6 +816,173 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_ph5: dcmi_pixclk_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/u5/stm32u5g9njhxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g9njhxq-pinctrl.dtsi
@@ -860,6 +860,173 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pe1: dcmi_d3_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_ph5: dcmi_pixclk_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_ph8: dcmi_hsync_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pi4: dcmi_d5_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pi5: dcmi_vsync_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pi6: dcmi_d6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pi7: dcmi_d7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u5g9vjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g9vjtxq-pinctrl.dtsi
@@ -436,6 +436,88 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u5g9zjjxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g9zjjxq-pinctrl.dtsi
@@ -608,6 +608,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/u5/stm32u5g9zjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g9zjtxq-pinctrl.dtsi
@@ -608,6 +608,138 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DCMI */
+
+			/omit-if-no-ref/ dcmi_hsync_pa4: dcmi_hsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pa6: dcmi_pixclk_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pa9: dcmi_d0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pa10: dcmi_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pb6: dcmi_d5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_vsync_pb7: dcmi_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pb8: dcmi_d6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pb9: dcmi_d7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_pc6: dcmi_d0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_pc7: dcmi_d1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc8: dcmi_d2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_pc9: dcmi_d3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pc11: dcmi_d2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pc11: dcmi_d4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d5_pd3: dcmi_d5_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_hsync_pd8: dcmi_hsync_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_pixclk_pd9: dcmi_pixclk_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_pe0: dcmi_d2_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_pe4: dcmi_d4_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d6_pe5: dcmi_d6_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d7_pe6: dcmi_d7_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d0_ph9: dcmi_d0_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d1_ph10: dcmi_d1_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d2_ph11: dcmi_d2_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d3_ph12: dcmi_d3_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dcmi_d4_ph14: dcmi_d4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/scripts/genpinctrl/stm32-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32-pinctrl-config.yaml
@@ -52,6 +52,10 @@
 - name: DAC_OUT
   match: "^DAC(?:\\d+)?_OUT\\d+$"
 
+- name: DCMI
+  match: "^DCMI_(?:HSYNC|PIXCLK|VSYNC|D[0-7])$"
+  slew-rate: very-high-speed
+
 - name: ETH_COL
   match: "^ETH_COL$"
   slew-rate: very-high-speed


### PR DESCRIPTION
Generate DCMI pins definitions for H7 family.

Related PR:

- https://github.com/zephyrproject-rtos/zephyr/pull/71462
- https://github.com/zephyrproject-rtos/zephyr/pull/71463