### PR TITLE
dts: st: h7: pinctrl.dtsi files including RCC MCO 1 pin

### DIFF
--- a/dts/st/h7/stm32h723vehx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vehx-pinctrl.dtsi
@@ -1781,6 +1781,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h723vetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vetx-pinctrl.dtsi
@@ -1781,6 +1781,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h723vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vghx-pinctrl.dtsi
@@ -1781,6 +1781,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h723vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vgtx-pinctrl.dtsi
@@ -1781,6 +1781,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h723zeix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zeix-pinctrl.dtsi
@@ -2440,6 +2440,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h723zetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zetx-pinctrl.dtsi
@@ -2412,6 +2412,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h723zgix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zgix-pinctrl.dtsi
@@ -2440,6 +2440,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h723zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zgtx-pinctrl.dtsi
@@ -2412,6 +2412,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725aeix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725aeix-pinctrl.dtsi
@@ -2728,6 +2728,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725agix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725agix-pinctrl.dtsi
@@ -2728,6 +2728,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725iekx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725iekx-pinctrl.dtsi
@@ -2872,6 +2872,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725ietx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725ietx-pinctrl.dtsi
@@ -2468,6 +2468,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725igkx-pinctrl.dtsi
@@ -2872,6 +2872,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725igtx-pinctrl.dtsi
@@ -2468,6 +2468,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725revx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725revx-pinctrl.dtsi
@@ -925,6 +925,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725rgvx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725rgvx-pinctrl.dtsi
@@ -925,6 +925,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725vehx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vehx-pinctrl.dtsi
@@ -1706,6 +1706,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725vetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vetx-pinctrl.dtsi
@@ -1590,6 +1590,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vghx-pinctrl.dtsi
@@ -1706,6 +1706,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vgtx-pinctrl.dtsi
@@ -1590,6 +1590,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725vgyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vgyx-pinctrl.dtsi
@@ -1524,6 +1524,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725zetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725zetx-pinctrl.dtsi
@@ -2145,6 +2145,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725zgtx-pinctrl.dtsi
@@ -2145,6 +2145,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h730abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730abixq-pinctrl.dtsi
@@ -2728,6 +2728,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h730ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730ibkxq-pinctrl.dtsi
@@ -2872,6 +2872,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h730ibtxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730ibtxq-pinctrl.dtsi
@@ -2468,6 +2468,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h730vbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730vbhx-pinctrl.dtsi
@@ -1781,6 +1781,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h730vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730vbtx-pinctrl.dtsi
@@ -1781,6 +1781,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h730zbix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730zbix-pinctrl.dtsi
@@ -2440,6 +2440,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h730zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730zbtx-pinctrl.dtsi
@@ -2412,6 +2412,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h733vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733vghx-pinctrl.dtsi
@@ -1781,6 +1781,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h733vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733vgtx-pinctrl.dtsi
@@ -1781,6 +1781,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h733zgix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733zgix-pinctrl.dtsi
@@ -2440,6 +2440,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h733zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733zgtx-pinctrl.dtsi
@@ -2412,6 +2412,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h735agix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735agix-pinctrl.dtsi
@@ -2728,6 +2728,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h735igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735igkx-pinctrl.dtsi
@@ -2872,6 +2872,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h735igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735igtx-pinctrl.dtsi
@@ -2468,6 +2468,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h735rgvx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735rgvx-pinctrl.dtsi
@@ -925,6 +925,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h735vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vghx-pinctrl.dtsi
@@ -1706,6 +1706,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h735vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vgtx-pinctrl.dtsi
@@ -1590,6 +1590,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h735vgyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vgyx-pinctrl.dtsi
@@ -1524,6 +1524,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h735zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735zgtx-pinctrl.dtsi
@@ -2145,6 +2145,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
@@ -1996,6 +1996,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
@@ -2255,6 +2255,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
@@ -2143,6 +2143,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
@@ -2143,6 +2143,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
@@ -1296,6 +1296,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
@@ -1296,6 +1296,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
@@ -2383,6 +2383,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
@@ -1766,6 +1766,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
@@ -2270,6 +2270,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
@@ -2673,6 +2673,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bitx-pinctrl.dtsi
@@ -2673,6 +2673,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igkx-pinctrl.dtsi
@@ -2433,6 +2433,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igtx-pinctrl.dtsi
@@ -2433,6 +2433,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iikx-pinctrl.dtsi
@@ -2433,6 +2433,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iitx-pinctrl.dtsi
@@ -2433,6 +2433,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
@@ -1454,6 +1454,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
@@ -1454,6 +1454,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vitx-pinctrl.dtsi
@@ -1454,6 +1454,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xghx-pinctrl.dtsi
@@ -2799,6 +2799,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xihx-pinctrl.dtsi
@@ -2799,6 +2799,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
@@ -1968,6 +1968,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zitx-pinctrl.dtsi
@@ -1968,6 +1968,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
@@ -2517,6 +2517,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h745bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bitx-pinctrl.dtsi
@@ -2517,6 +2517,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h745igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igkx-pinctrl.dtsi
@@ -2393,6 +2393,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h745igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igtx-pinctrl.dtsi
@@ -2024,6 +2024,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h745iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iikx-pinctrl.dtsi
@@ -2393,6 +2393,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h745iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iitx-pinctrl.dtsi
@@ -2024,6 +2024,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h745xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xghx-pinctrl.dtsi
@@ -2799,6 +2799,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h745xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xihx-pinctrl.dtsi
@@ -2799,6 +2799,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
@@ -1764,6 +1764,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h745zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zitx-pinctrl.dtsi
@@ -1764,6 +1764,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
@@ -1968,6 +1968,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
@@ -2445,6 +2445,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h747bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bitx-pinctrl.dtsi
@@ -2445,6 +2445,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h747igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747igtx-pinctrl.dtsi
@@ -1968,6 +1968,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h747iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747iitx-pinctrl.dtsi
@@ -1968,6 +1968,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h747xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xghx-pinctrl.dtsi
@@ -2799,6 +2799,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h747xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xihx-pinctrl.dtsi
@@ -2799,6 +2799,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
@@ -1727,6 +1727,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
@@ -2433,6 +2433,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
@@ -2433,6 +2433,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
@@ -1454,6 +1454,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
@@ -2799,6 +2799,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
@@ -1968,6 +1968,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h753aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753aiix-pinctrl.dtsi
@@ -2270,6 +2270,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h753bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753bitx-pinctrl.dtsi
@@ -2673,6 +2673,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h753iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iikx-pinctrl.dtsi
@@ -2433,6 +2433,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h753iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iitx-pinctrl.dtsi
@@ -2433,6 +2433,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h753vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vihx-pinctrl.dtsi
@@ -1454,6 +1454,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h753vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vitx-pinctrl.dtsi
@@ -1454,6 +1454,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h753xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753xihx-pinctrl.dtsi
@@ -2799,6 +2799,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h753zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753zitx-pinctrl.dtsi
@@ -1968,6 +1968,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h755bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755bitx-pinctrl.dtsi
@@ -2517,6 +2517,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h755iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iikx-pinctrl.dtsi
@@ -2393,6 +2393,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h755iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iitx-pinctrl.dtsi
@@ -2024,6 +2024,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h755xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755xihx-pinctrl.dtsi
@@ -2799,6 +2799,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h755zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755zitx-pinctrl.dtsi
@@ -1764,6 +1764,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h757aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757aiix-pinctrl.dtsi
@@ -1968,6 +1968,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h757bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757bitx-pinctrl.dtsi
@@ -2445,6 +2445,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h757iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757iitx-pinctrl.dtsi
@@ -1968,6 +1968,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h757xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757xihx-pinctrl.dtsi
@@ -2799,6 +2799,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
@@ -1727,6 +1727,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
@@ -2260,6 +2260,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
@@ -2444,6 +2444,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
@@ -2378,6 +2378,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
@@ -2444,6 +2444,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
@@ -2073,6 +2073,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
@@ -2839,6 +2839,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
@@ -2729,6 +2729,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3qiyxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3qiyxq-pinctrl.dtsi
@@ -1626,6 +1626,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3r(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3r(g-i)tx-pinctrl.dtsi
@@ -930,6 +930,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
@@ -1492,6 +1492,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
@@ -1417,6 +1417,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
@@ -1492,6 +1492,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
@@ -1315,6 +1315,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
@@ -2017,6 +2017,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
@@ -1783,6 +1783,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
@@ -2260,6 +2260,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
@@ -2378,6 +2378,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
@@ -2444,6 +2444,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b0rbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0rbtx-pinctrl.dtsi
@@ -930,6 +930,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
@@ -1492,6 +1492,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
@@ -2017,6 +2017,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
@@ -2260,6 +2260,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
@@ -2444,6 +2444,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
@@ -2378,6 +2378,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
@@ -2444,6 +2444,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
@@ -2073,6 +2073,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
@@ -2839,6 +2839,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
@@ -2729,6 +2729,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3qiyxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3qiyxq-pinctrl.dtsi
@@ -1626,6 +1626,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3ritx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3ritx-pinctrl.dtsi
@@ -930,6 +930,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
@@ -1492,6 +1492,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
@@ -1417,6 +1417,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
@@ -1492,6 +1492,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
@@ -1315,6 +1315,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
@@ -2017,6 +2017,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
@@ -1783,6 +1783,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* RCC_MCO_1 */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/scripts/genpinctrl/stm32-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32-pinctrl-config.yaml
@@ -194,6 +194,10 @@
 - name: LTDC
   match: "^LTDC_(?:DE|CLK|HSYNC|VSYNC|R[0-7]|G[0-7]|B[0-7])$"
 
+- name: RCC_MCO_1
+  match: "^RCC_MCO_1$"
+  slew-rate: very-high-speed
+
 - name: OCTOSPI
   match: "^OCTOSPI(.*)(?:CLK|NCS|DQS|IO[0-7])$"
   slew-rate: very-high-speed


### PR DESCRIPTION
Generate RCC MCO1 pin definitions for H7 family.

Related PR:

- https://github.com/zephyrproject-rtos/zephyr/pull/71462
- https://github.com/zephyrproject-rtos/zephyr/pull/71463