### PR TITLE
stm32cube: Remove legacy headers inclusion

### DIFF
--- a/stm32cube/CMakeLists.txt
+++ b/stm32cube/CMakeLists.txt
@@ -65,7 +65,6 @@ foreach(stm_soc ${stm_socs})
     zephyr_include_directories(
 	  ${stm_soc}x/soc
 	  ${stm_soc}x/drivers/include
-	  ${stm_soc}x/drivers/include/Legacy
 	  )
 
     add_subdirectory(${stm_soc}x)


### PR DESCRIPTION
These headers provide redirections from legacy symbols definitions. They are provided only for backward compatibility, but in context of Zephyr integration we're supposed to update stm32 drivers to stay up to date with latest versions ath using deprecated symbols.

Purely remove the inclusion and update symbols used in Zephyr if required.

As a benefit this should minimize the possibility of conflicts with Zephyr or other subsystems API (such as POSIX).