### PR TITLE
dts: Add DFSDM pins to pinctrl.dtsi files

### DIFF
--- a/dts/st/f4/stm32f412c(e-g)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412c(e-g)ux-pinctrl.dtsi
@@ -238,6 +238,48 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa4: dfsdm1_datin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa5: dfsdm1_ckin1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f412r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412r(e-g)tx-pinctrl.dtsi
@@ -318,6 +318,63 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa4: dfsdm1_datin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa5: dfsdm1_ckin1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f412r(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412r(e-g)yx-pinctrl.dtsi
@@ -318,6 +318,63 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa4: dfsdm1_datin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa5: dfsdm1_ckin1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f412r(e-g)yxp-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412r(e-g)yxp-pinctrl.dtsi
@@ -318,6 +318,63 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa4: dfsdm1_datin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa5: dfsdm1_ckin1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f412v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412v(e-g)hx-pinctrl.dtsi
@@ -451,6 +451,108 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa4: dfsdm1_datin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa5: dfsdm1_ckin1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f412v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412v(e-g)tx-pinctrl.dtsi
@@ -451,6 +451,108 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa4: dfsdm1_datin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa5: dfsdm1_ckin1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f412z(e-g)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412z(e-g)jx-pinctrl.dtsi
@@ -601,6 +601,108 @@
 				pinmux = <STM32_PINMUX('G', 12, AF9)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa4: dfsdm1_datin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa5: dfsdm1_ckin1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f412z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412z(e-g)tx-pinctrl.dtsi
@@ -601,6 +601,108 @@
 				pinmux = <STM32_PINMUX('G', 12, AF9)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa4: dfsdm1_datin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa5: dfsdm1_ckin1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f413c(g-h)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413c(g-h)ux-pinctrl.dtsi
@@ -266,6 +266,108 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa4: dfsdm1_datin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa5: dfsdm1_ckin1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa8: dfsdm1_ckout_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa6: dfsdm2_ckin1_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin3_pa9: dfsdm2_ckin3_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin3_pa10: dfsdm2_datin3_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin5_pa11: dfsdm2_ckin5_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin5_pa12: dfsdm2_datin5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin7_pb6: dfsdm2_ckin7_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin7_pb7: dfsdm2_datin7_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb8: dfsdm2_ckin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb9: dfsdm2_datin1_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb10: dfsdm2_ckout_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f413m(g-h)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413m(g-h)yx-pinctrl.dtsi
@@ -391,6 +391,228 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa4: dfsdm1_datin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa5: dfsdm1_ckin1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa8: dfsdm1_ckout_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa6: dfsdm2_ckin1_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin3_pa9: dfsdm2_ckin3_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin3_pa10: dfsdm2_datin3_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin5_pa11: dfsdm2_ckin5_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin5_pa12: dfsdm2_datin5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin7_pb6: dfsdm2_ckin7_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin7_pb7: dfsdm2_datin7_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb8: dfsdm2_ckin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb9: dfsdm2_datin1_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb10: dfsdm2_ckout_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin4_pc0: dfsdm2_ckin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin4_pc1: dfsdm2_datin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin7_pc2: dfsdm2_datin7_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin7_pc3: dfsdm2_ckin7_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin2_pc4: dfsdm2_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin2_pc5: dfsdm2_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin6_pc6: dfsdm2_datin6_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin6_pc7: dfsdm2_ckin6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin3_pc8: dfsdm2_ckin3_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin3_pc9: dfsdm2_datin3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin5_pc10: dfsdm2_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin5_pc11: dfsdm2_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin6_pd0: dfsdm2_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd2: dfsdm2_ckout_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pe10: dfsdm2_datin0_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pe11: dfsdm2_ckin0_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin7_pe12: dfsdm2_datin7_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin7_pe13: dfsdm2_ckin7_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pe14: dfsdm2_datin1_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pe15: dfsdm2_ckin1_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f413r(g-h)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413r(g-h)tx-pinctrl.dtsi
@@ -346,6 +346,188 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa4: dfsdm1_datin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa5: dfsdm1_ckin1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa8: dfsdm1_ckout_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa6: dfsdm2_ckin1_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin3_pa9: dfsdm2_ckin3_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin3_pa10: dfsdm2_datin3_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin5_pa11: dfsdm2_ckin5_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin5_pa12: dfsdm2_datin5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin7_pb6: dfsdm2_ckin7_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin7_pb7: dfsdm2_datin7_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb8: dfsdm2_ckin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb9: dfsdm2_datin1_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb10: dfsdm2_ckout_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin4_pc0: dfsdm2_ckin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin4_pc1: dfsdm2_datin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin7_pc2: dfsdm2_datin7_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin7_pc3: dfsdm2_ckin7_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin2_pc4: dfsdm2_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin2_pc5: dfsdm2_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin6_pc6: dfsdm2_datin6_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin6_pc7: dfsdm2_ckin6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin3_pc8: dfsdm2_ckin3_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin3_pc9: dfsdm2_datin3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin5_pc10: dfsdm2_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin5_pc11: dfsdm2_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd2: dfsdm2_ckout_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f413v(g-h)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413v(g-h)hx-pinctrl.dtsi
@@ -479,6 +479,308 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa4: dfsdm1_datin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa5: dfsdm1_ckin1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa8: dfsdm1_ckout_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa6: dfsdm2_ckin1_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin3_pa9: dfsdm2_ckin3_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin3_pa10: dfsdm2_datin3_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin5_pa11: dfsdm2_ckin5_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin5_pa12: dfsdm2_datin5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin7_pb6: dfsdm2_ckin7_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin7_pb7: dfsdm2_datin7_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb8: dfsdm2_ckin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb9: dfsdm2_datin1_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb10: dfsdm2_ckout_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin4_pc0: dfsdm2_ckin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin4_pc1: dfsdm2_datin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin7_pc2: dfsdm2_datin7_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin7_pc3: dfsdm2_ckin7_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin2_pc4: dfsdm2_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin2_pc5: dfsdm2_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin6_pc6: dfsdm2_datin6_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin6_pc7: dfsdm2_ckin6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin3_pc8: dfsdm2_ckin3_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin3_pc9: dfsdm2_datin3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin5_pc10: dfsdm2_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin5_pc11: dfsdm2_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin6_pd0: dfsdm2_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin6_pd1: dfsdm2_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd2: dfsdm2_ckout_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd5: dfsdm2_ckout_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin2_pd11: dfsdm2_datin2_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin2_pd12: dfsdm2_ckin2_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pd14: dfsdm2_ckin0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pd15: dfsdm2_datin0_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin4_pe0: dfsdm2_ckin4_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin4_pe1: dfsdm2_datin4_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pe10: dfsdm2_datin0_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pe11: dfsdm2_ckin0_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin7_pe12: dfsdm2_datin7_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin7_pe13: dfsdm2_ckin7_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pe14: dfsdm2_datin1_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pe15: dfsdm2_ckin1_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f413v(g-h)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413v(g-h)tx-pinctrl.dtsi
@@ -479,6 +479,308 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa4: dfsdm1_datin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa5: dfsdm1_ckin1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa8: dfsdm1_ckout_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa6: dfsdm2_ckin1_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin3_pa9: dfsdm2_ckin3_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin3_pa10: dfsdm2_datin3_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin5_pa11: dfsdm2_ckin5_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin5_pa12: dfsdm2_datin5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin7_pb6: dfsdm2_ckin7_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin7_pb7: dfsdm2_datin7_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb8: dfsdm2_ckin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb9: dfsdm2_datin1_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb10: dfsdm2_ckout_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin4_pc0: dfsdm2_ckin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin4_pc1: dfsdm2_datin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin7_pc2: dfsdm2_datin7_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin7_pc3: dfsdm2_ckin7_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin2_pc4: dfsdm2_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin2_pc5: dfsdm2_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin6_pc6: dfsdm2_datin6_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin6_pc7: dfsdm2_ckin6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin3_pc8: dfsdm2_ckin3_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin3_pc9: dfsdm2_datin3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin5_pc10: dfsdm2_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin5_pc11: dfsdm2_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin6_pd0: dfsdm2_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin6_pd1: dfsdm2_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd2: dfsdm2_ckout_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd5: dfsdm2_ckout_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin2_pd11: dfsdm2_datin2_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin2_pd12: dfsdm2_ckin2_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pd14: dfsdm2_ckin0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pd15: dfsdm2_datin0_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin4_pe0: dfsdm2_ckin4_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin4_pe1: dfsdm2_datin4_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pe10: dfsdm2_datin0_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pe11: dfsdm2_ckin0_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin7_pe12: dfsdm2_datin7_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin7_pe13: dfsdm2_ckin7_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pe14: dfsdm2_datin1_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pe15: dfsdm2_ckin1_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f413z(g-h)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413z(g-h)jx-pinctrl.dtsi
@@ -629,6 +629,308 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa4: dfsdm1_datin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa5: dfsdm1_ckin1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa8: dfsdm1_ckout_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa6: dfsdm2_ckin1_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin3_pa9: dfsdm2_ckin3_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin3_pa10: dfsdm2_datin3_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin5_pa11: dfsdm2_ckin5_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin5_pa12: dfsdm2_datin5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin7_pb6: dfsdm2_ckin7_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin7_pb7: dfsdm2_datin7_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb8: dfsdm2_ckin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb9: dfsdm2_datin1_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb10: dfsdm2_ckout_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin4_pc0: dfsdm2_ckin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin4_pc1: dfsdm2_datin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin7_pc2: dfsdm2_datin7_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin7_pc3: dfsdm2_ckin7_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin2_pc4: dfsdm2_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin2_pc5: dfsdm2_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin6_pc6: dfsdm2_datin6_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin6_pc7: dfsdm2_ckin6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin3_pc8: dfsdm2_ckin3_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin3_pc9: dfsdm2_datin3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin5_pc10: dfsdm2_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin5_pc11: dfsdm2_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin6_pd0: dfsdm2_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin6_pd1: dfsdm2_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd2: dfsdm2_ckout_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd5: dfsdm2_ckout_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin2_pd11: dfsdm2_datin2_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin2_pd12: dfsdm2_ckin2_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pd14: dfsdm2_ckin0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pd15: dfsdm2_datin0_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin4_pe0: dfsdm2_ckin4_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin4_pe1: dfsdm2_datin4_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pe10: dfsdm2_datin0_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pe11: dfsdm2_ckin0_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin7_pe12: dfsdm2_datin7_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin7_pe13: dfsdm2_ckin7_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pe14: dfsdm2_datin1_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pe15: dfsdm2_ckin1_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f413z(g-h)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413z(g-h)tx-pinctrl.dtsi
@@ -629,6 +629,308 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa4: dfsdm1_datin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa5: dfsdm1_ckin1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa8: dfsdm1_ckout_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa6: dfsdm2_ckin1_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin3_pa9: dfsdm2_ckin3_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin3_pa10: dfsdm2_datin3_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin5_pa11: dfsdm2_ckin5_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin5_pa12: dfsdm2_datin5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin7_pb6: dfsdm2_ckin7_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin7_pb7: dfsdm2_datin7_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb8: dfsdm2_ckin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb9: dfsdm2_datin1_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb10: dfsdm2_ckout_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin4_pc0: dfsdm2_ckin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin4_pc1: dfsdm2_datin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin7_pc2: dfsdm2_datin7_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin7_pc3: dfsdm2_ckin7_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin2_pc4: dfsdm2_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin2_pc5: dfsdm2_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin6_pc6: dfsdm2_datin6_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin6_pc7: dfsdm2_ckin6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin3_pc8: dfsdm2_ckin3_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin3_pc9: dfsdm2_datin3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin5_pc10: dfsdm2_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin5_pc11: dfsdm2_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin6_pd0: dfsdm2_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin6_pd1: dfsdm2_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd2: dfsdm2_ckout_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd5: dfsdm2_ckout_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin2_pd11: dfsdm2_datin2_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin2_pd12: dfsdm2_ckin2_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pd14: dfsdm2_ckin0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pd15: dfsdm2_datin0_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin4_pe0: dfsdm2_ckin4_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin4_pe1: dfsdm2_datin4_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pe10: dfsdm2_datin0_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pe11: dfsdm2_ckin0_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin7_pe12: dfsdm2_datin7_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin7_pe13: dfsdm2_ckin7_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pe14: dfsdm2_datin1_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pe15: dfsdm2_ckin1_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f423chux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423chux-pinctrl.dtsi
@@ -266,6 +266,108 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa4: dfsdm1_datin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa5: dfsdm1_ckin1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa8: dfsdm1_ckout_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa6: dfsdm2_ckin1_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin3_pa9: dfsdm2_ckin3_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin3_pa10: dfsdm2_datin3_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin5_pa11: dfsdm2_ckin5_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin5_pa12: dfsdm2_datin5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin7_pb6: dfsdm2_ckin7_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin7_pb7: dfsdm2_datin7_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb8: dfsdm2_ckin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb9: dfsdm2_datin1_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb10: dfsdm2_ckout_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f423mhyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423mhyx-pinctrl.dtsi
@@ -391,6 +391,228 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa4: dfsdm1_datin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa5: dfsdm1_ckin1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa8: dfsdm1_ckout_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa6: dfsdm2_ckin1_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin3_pa9: dfsdm2_ckin3_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin3_pa10: dfsdm2_datin3_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin5_pa11: dfsdm2_ckin5_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin5_pa12: dfsdm2_datin5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin7_pb6: dfsdm2_ckin7_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin7_pb7: dfsdm2_datin7_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb8: dfsdm2_ckin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb9: dfsdm2_datin1_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb10: dfsdm2_ckout_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin4_pc0: dfsdm2_ckin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin4_pc1: dfsdm2_datin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin7_pc2: dfsdm2_datin7_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin7_pc3: dfsdm2_ckin7_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin2_pc4: dfsdm2_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin2_pc5: dfsdm2_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin6_pc6: dfsdm2_datin6_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin6_pc7: dfsdm2_ckin6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin3_pc8: dfsdm2_ckin3_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin3_pc9: dfsdm2_datin3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin5_pc10: dfsdm2_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin5_pc11: dfsdm2_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin6_pd0: dfsdm2_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd2: dfsdm2_ckout_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pe10: dfsdm2_datin0_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pe11: dfsdm2_ckin0_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin7_pe12: dfsdm2_datin7_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin7_pe13: dfsdm2_ckin7_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pe14: dfsdm2_datin1_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pe15: dfsdm2_ckin1_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f423rhtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423rhtx-pinctrl.dtsi
@@ -346,6 +346,188 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa4: dfsdm1_datin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa5: dfsdm1_ckin1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa8: dfsdm1_ckout_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa6: dfsdm2_ckin1_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin3_pa9: dfsdm2_ckin3_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin3_pa10: dfsdm2_datin3_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin5_pa11: dfsdm2_ckin5_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin5_pa12: dfsdm2_datin5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin7_pb6: dfsdm2_ckin7_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin7_pb7: dfsdm2_datin7_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb8: dfsdm2_ckin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb9: dfsdm2_datin1_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb10: dfsdm2_ckout_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin4_pc0: dfsdm2_ckin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin4_pc1: dfsdm2_datin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin7_pc2: dfsdm2_datin7_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin7_pc3: dfsdm2_ckin7_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin2_pc4: dfsdm2_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin2_pc5: dfsdm2_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin6_pc6: dfsdm2_datin6_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin6_pc7: dfsdm2_ckin6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin3_pc8: dfsdm2_ckin3_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin3_pc9: dfsdm2_datin3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin5_pc10: dfsdm2_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin5_pc11: dfsdm2_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd2: dfsdm2_ckout_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f423vhhx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423vhhx-pinctrl.dtsi
@@ -479,6 +479,308 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa4: dfsdm1_datin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa5: dfsdm1_ckin1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa8: dfsdm1_ckout_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa6: dfsdm2_ckin1_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin3_pa9: dfsdm2_ckin3_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin3_pa10: dfsdm2_datin3_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin5_pa11: dfsdm2_ckin5_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin5_pa12: dfsdm2_datin5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin7_pb6: dfsdm2_ckin7_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin7_pb7: dfsdm2_datin7_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb8: dfsdm2_ckin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb9: dfsdm2_datin1_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb10: dfsdm2_ckout_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin4_pc0: dfsdm2_ckin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin4_pc1: dfsdm2_datin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin7_pc2: dfsdm2_datin7_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin7_pc3: dfsdm2_ckin7_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin2_pc4: dfsdm2_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin2_pc5: dfsdm2_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin6_pc6: dfsdm2_datin6_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin6_pc7: dfsdm2_ckin6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin3_pc8: dfsdm2_ckin3_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin3_pc9: dfsdm2_datin3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin5_pc10: dfsdm2_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin5_pc11: dfsdm2_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin6_pd0: dfsdm2_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin6_pd1: dfsdm2_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd2: dfsdm2_ckout_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd5: dfsdm2_ckout_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin2_pd11: dfsdm2_datin2_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin2_pd12: dfsdm2_ckin2_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pd14: dfsdm2_ckin0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pd15: dfsdm2_datin0_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin4_pe0: dfsdm2_ckin4_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin4_pe1: dfsdm2_datin4_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pe10: dfsdm2_datin0_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pe11: dfsdm2_ckin0_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin7_pe12: dfsdm2_datin7_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin7_pe13: dfsdm2_ckin7_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pe14: dfsdm2_datin1_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pe15: dfsdm2_ckin1_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f423vhtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423vhtx-pinctrl.dtsi
@@ -479,6 +479,308 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa4: dfsdm1_datin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa5: dfsdm1_ckin1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa8: dfsdm1_ckout_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa6: dfsdm2_ckin1_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin3_pa9: dfsdm2_ckin3_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin3_pa10: dfsdm2_datin3_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin5_pa11: dfsdm2_ckin5_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin5_pa12: dfsdm2_datin5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin7_pb6: dfsdm2_ckin7_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin7_pb7: dfsdm2_datin7_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb8: dfsdm2_ckin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb9: dfsdm2_datin1_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb10: dfsdm2_ckout_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin4_pc0: dfsdm2_ckin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin4_pc1: dfsdm2_datin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin7_pc2: dfsdm2_datin7_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin7_pc3: dfsdm2_ckin7_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin2_pc4: dfsdm2_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin2_pc5: dfsdm2_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin6_pc6: dfsdm2_datin6_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin6_pc7: dfsdm2_ckin6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin3_pc8: dfsdm2_ckin3_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin3_pc9: dfsdm2_datin3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin5_pc10: dfsdm2_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin5_pc11: dfsdm2_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin6_pd0: dfsdm2_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin6_pd1: dfsdm2_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd2: dfsdm2_ckout_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd5: dfsdm2_ckout_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin2_pd11: dfsdm2_datin2_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin2_pd12: dfsdm2_ckin2_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pd14: dfsdm2_ckin0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pd15: dfsdm2_datin0_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin4_pe0: dfsdm2_ckin4_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin4_pe1: dfsdm2_datin4_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pe10: dfsdm2_datin0_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pe11: dfsdm2_ckin0_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin7_pe12: dfsdm2_datin7_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin7_pe13: dfsdm2_ckin7_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pe14: dfsdm2_datin1_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pe15: dfsdm2_ckin1_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f423zhjx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423zhjx-pinctrl.dtsi
@@ -629,6 +629,308 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa4: dfsdm1_datin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa5: dfsdm1_ckin1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa8: dfsdm1_ckout_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa6: dfsdm2_ckin1_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin3_pa9: dfsdm2_ckin3_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin3_pa10: dfsdm2_datin3_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin5_pa11: dfsdm2_ckin5_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin5_pa12: dfsdm2_datin5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin7_pb6: dfsdm2_ckin7_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin7_pb7: dfsdm2_datin7_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb8: dfsdm2_ckin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb9: dfsdm2_datin1_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb10: dfsdm2_ckout_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin4_pc0: dfsdm2_ckin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin4_pc1: dfsdm2_datin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin7_pc2: dfsdm2_datin7_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin7_pc3: dfsdm2_ckin7_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin2_pc4: dfsdm2_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin2_pc5: dfsdm2_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin6_pc6: dfsdm2_datin6_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin6_pc7: dfsdm2_ckin6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin3_pc8: dfsdm2_ckin3_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin3_pc9: dfsdm2_datin3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin5_pc10: dfsdm2_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin5_pc11: dfsdm2_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin6_pd0: dfsdm2_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin6_pd1: dfsdm2_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd2: dfsdm2_ckout_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd5: dfsdm2_ckout_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin2_pd11: dfsdm2_datin2_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin2_pd12: dfsdm2_ckin2_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pd14: dfsdm2_ckin0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pd15: dfsdm2_datin0_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin4_pe0: dfsdm2_ckin4_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin4_pe1: dfsdm2_datin4_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pe10: dfsdm2_datin0_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pe11: dfsdm2_ckin0_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin7_pe12: dfsdm2_datin7_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin7_pe13: dfsdm2_ckin7_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pe14: dfsdm2_datin1_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pe15: dfsdm2_ckin1_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f423zhtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423zhtx-pinctrl.dtsi
@@ -629,6 +629,308 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa4: dfsdm1_datin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa5: dfsdm1_ckin1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa8: dfsdm1_ckout_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa6: dfsdm2_ckin1_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin3_pa9: dfsdm2_ckin3_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin3_pa10: dfsdm2_datin3_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin5_pa11: dfsdm2_ckin5_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin5_pa12: dfsdm2_datin5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin7_pb6: dfsdm2_ckin7_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin7_pb7: dfsdm2_datin7_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb8: dfsdm2_ckin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb9: dfsdm2_datin1_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb10: dfsdm2_ckout_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin4_pc0: dfsdm2_ckin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin4_pc1: dfsdm2_datin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin7_pc2: dfsdm2_datin7_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin7_pc3: dfsdm2_ckin7_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin2_pc4: dfsdm2_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin2_pc5: dfsdm2_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin6_pc6: dfsdm2_datin6_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin6_pc7: dfsdm2_ckin6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin3_pc8: dfsdm2_ckin3_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin3_pc9: dfsdm2_datin3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin5_pc10: dfsdm2_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin5_pc11: dfsdm2_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin6_pd0: dfsdm2_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin6_pd1: dfsdm2_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd2: dfsdm2_ckout_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd5: dfsdm2_ckout_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin2_pd11: dfsdm2_datin2_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin2_pd12: dfsdm2_ckin2_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pd14: dfsdm2_ckin0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pd15: dfsdm2_datin0_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin4_pe0: dfsdm2_ckin4_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin4_pe1: dfsdm2_datin4_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pe10: dfsdm2_datin0_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pe11: dfsdm2_ckin0_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin7_pe12: dfsdm2_datin7_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin7_pe13: dfsdm2_ckin7_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pe14: dfsdm2_datin1_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pe15: dfsdm2_ckin1_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
@@ -1131,6 +1131,263 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
@@ -1019,6 +1019,263 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
@@ -1019,6 +1019,263 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
@@ -1131,6 +1131,263 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f765v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765v(g-i)hx-pinctrl.dtsi
@@ -676,6 +676,253 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f765v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765v(g-i)tx-pinctrl.dtsi
@@ -676,6 +676,253 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
@@ -851,6 +851,263 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
@@ -1131,6 +1131,263 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
@@ -1019,6 +1019,263 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
@@ -1019,6 +1019,263 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
@@ -1131,6 +1131,263 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f767vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vghx-pinctrl.dtsi
@@ -676,6 +676,253 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
@@ -676,6 +676,253 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f767vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vihx-pinctrl.dtsi
@@ -676,6 +676,253 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f767vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vitx-pinctrl.dtsi
@@ -676,6 +676,253 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
@@ -851,6 +851,263 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f767zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zitx-pinctrl.dtsi
@@ -851,6 +851,263 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
@@ -915,6 +915,238 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_sdnwe_pa7: fmc_sdnwe_pa7 {

--- a/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
@@ -915,6 +915,238 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_sdnwe_pa7: fmc_sdnwe_pa7 {

--- a/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
@@ -1095,6 +1095,263 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f769igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769igtx-pinctrl.dtsi
@@ -944,6 +944,263 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f769iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769iitx-pinctrl.dtsi
@@ -944,6 +944,263 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f769nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nghx-pinctrl.dtsi
@@ -1095,6 +1095,263 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f769nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nihx-pinctrl.dtsi
@@ -1095,6 +1095,263 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f777bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777bitx-pinctrl.dtsi
@@ -1131,6 +1131,263 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f777iikx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iikx-pinctrl.dtsi
@@ -1019,6 +1019,263 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f777iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iitx-pinctrl.dtsi
@@ -1019,6 +1019,263 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f777nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777nihx-pinctrl.dtsi
@@ -1131,6 +1131,263 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f777vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vihx-pinctrl.dtsi
@@ -676,6 +676,253 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f777vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vitx-pinctrl.dtsi
@@ -676,6 +676,253 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f777zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777zitx-pinctrl.dtsi
@@ -851,6 +851,263 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
@@ -915,6 +915,238 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_sdnwe_pa7: fmc_sdnwe_pa7 {

--- a/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
@@ -915,6 +915,238 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_sdnwe_pa7: fmc_sdnwe_pa7 {

--- a/dts/st/f7/stm32f779bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779bitx-pinctrl.dtsi
@@ -1095,6 +1095,263 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f779iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779iitx-pinctrl.dtsi
@@ -944,6 +944,263 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/f7/stm32f779nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779nihx-pinctrl.dtsi
@@ -1095,6 +1095,263 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h723vehx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vehx-pinctrl.dtsi
@@ -626,6 +626,233 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h723vetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vetx-pinctrl.dtsi
@@ -626,6 +626,233 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h723vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vghx-pinctrl.dtsi
@@ -626,6 +626,233 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h723vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vgtx-pinctrl.dtsi
@@ -626,6 +626,233 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h723zeix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zeix-pinctrl.dtsi
@@ -869,6 +869,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h723zetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zetx-pinctrl.dtsi
@@ -841,6 +841,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h723zgix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zgix-pinctrl.dtsi
@@ -869,6 +869,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h723zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zgtx-pinctrl.dtsi
@@ -841,6 +841,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h725aeix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725aeix-pinctrl.dtsi
@@ -981,6 +981,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h725agix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725agix-pinctrl.dtsi
@@ -981,6 +981,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h725iekx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725iekx-pinctrl.dtsi
@@ -1031,6 +1031,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h725ietx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725ietx-pinctrl.dtsi
@@ -869,6 +869,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h725igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725igkx-pinctrl.dtsi
@@ -1031,6 +1031,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h725igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725igtx-pinctrl.dtsi
@@ -869,6 +869,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h725revx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725revx-pinctrl.dtsi
@@ -435,6 +435,118 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h725rgvx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725rgvx-pinctrl.dtsi
@@ -435,6 +435,118 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h725vehx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vehx-pinctrl.dtsi
@@ -606,6 +606,218 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h725vetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vetx-pinctrl.dtsi
@@ -559,6 +559,188 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h725vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vghx-pinctrl.dtsi
@@ -606,6 +606,218 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h725vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vgtx-pinctrl.dtsi
@@ -559,6 +559,188 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h725vgyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vgyx-pinctrl.dtsi
@@ -539,6 +539,168 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h725zetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725zetx-pinctrl.dtsi
@@ -753,6 +753,238 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h725zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725zgtx-pinctrl.dtsi
@@ -753,6 +753,238 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h730abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730abixq-pinctrl.dtsi
@@ -981,6 +981,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h730ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730ibkxq-pinctrl.dtsi
@@ -1031,6 +1031,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h730ibtxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730ibtxq-pinctrl.dtsi
@@ -869,6 +869,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h730vbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730vbhx-pinctrl.dtsi
@@ -626,6 +626,233 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h730vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730vbtx-pinctrl.dtsi
@@ -626,6 +626,233 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h730zbix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730zbix-pinctrl.dtsi
@@ -869,6 +869,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h730zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730zbtx-pinctrl.dtsi
@@ -841,6 +841,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h733vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733vghx-pinctrl.dtsi
@@ -626,6 +626,233 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h733vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733vgtx-pinctrl.dtsi
@@ -626,6 +626,233 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h733zgix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733zgix-pinctrl.dtsi
@@ -869,6 +869,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h733zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733zgtx-pinctrl.dtsi
@@ -841,6 +841,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h735agix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735agix-pinctrl.dtsi
@@ -981,6 +981,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h735igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735igkx-pinctrl.dtsi
@@ -1031,6 +1031,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h735igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735igtx-pinctrl.dtsi
@@ -869,6 +869,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h735rgvx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735rgvx-pinctrl.dtsi
@@ -435,6 +435,118 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h735vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vghx-pinctrl.dtsi
@@ -606,6 +606,218 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h735vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vgtx-pinctrl.dtsi
@@ -559,6 +559,188 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h735vgyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vgyx-pinctrl.dtsi
@@ -539,6 +539,168 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h735zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735zgtx-pinctrl.dtsi
@@ -753,6 +753,238 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
@@ -961,6 +961,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
@@ -1130,6 +1130,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
@@ -1018,6 +1018,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
@@ -1018,6 +1018,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
@@ -621,6 +621,233 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
@@ -621,6 +621,233 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
@@ -1210,6 +1210,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
@@ -836,6 +836,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
@@ -961,6 +961,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
@@ -1130,6 +1130,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h743bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bitx-pinctrl.dtsi
@@ -1130,6 +1130,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h743igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igkx-pinctrl.dtsi
@@ -1018,6 +1018,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h743igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igtx-pinctrl.dtsi
@@ -1018,6 +1018,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h743iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iikx-pinctrl.dtsi
@@ -1018,6 +1018,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h743iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iitx-pinctrl.dtsi
@@ -1018,6 +1018,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
@@ -621,6 +621,233 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
@@ -621,6 +621,233 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h743vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vitx-pinctrl.dtsi
@@ -621,6 +621,233 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h743xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xghx-pinctrl.dtsi
@@ -1210,6 +1210,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h743xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xihx-pinctrl.dtsi
@@ -1210,6 +1210,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
@@ -836,6 +836,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h743zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zitx-pinctrl.dtsi
@@ -836,6 +836,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
@@ -1058,6 +1058,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h745bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bitx-pinctrl.dtsi
@@ -1058,6 +1058,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h745igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igkx-pinctrl.dtsi
@@ -1030,6 +1030,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h745igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igtx-pinctrl.dtsi
@@ -864,6 +864,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h745iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iikx-pinctrl.dtsi
@@ -1030,6 +1030,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h745iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iitx-pinctrl.dtsi
@@ -864,6 +864,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h745xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xghx-pinctrl.dtsi
@@ -1210,6 +1210,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h745xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xihx-pinctrl.dtsi
@@ -1210,6 +1210,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
@@ -744,6 +744,238 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h745zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zitx-pinctrl.dtsi
@@ -744,6 +744,238 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
@@ -836,6 +836,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
@@ -1022,6 +1022,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h747bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bitx-pinctrl.dtsi
@@ -1022,6 +1022,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h747igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747igtx-pinctrl.dtsi
@@ -836,6 +836,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h747iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747iitx-pinctrl.dtsi
@@ -836,6 +836,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h747xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xghx-pinctrl.dtsi
@@ -1210,6 +1210,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h747xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xihx-pinctrl.dtsi
@@ -1210,6 +1210,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
@@ -737,6 +737,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
@@ -1018,6 +1018,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
@@ -1018,6 +1018,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
@@ -621,6 +621,233 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
@@ -1210,6 +1210,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
@@ -836,6 +836,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h753aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753aiix-pinctrl.dtsi
@@ -961,6 +961,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h753bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753bitx-pinctrl.dtsi
@@ -1130,6 +1130,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h753iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iikx-pinctrl.dtsi
@@ -1018,6 +1018,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h753iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iitx-pinctrl.dtsi
@@ -1018,6 +1018,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h753vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vihx-pinctrl.dtsi
@@ -621,6 +621,233 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h753vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vitx-pinctrl.dtsi
@@ -621,6 +621,233 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h753xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753xihx-pinctrl.dtsi
@@ -1210,6 +1210,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h753zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753zitx-pinctrl.dtsi
@@ -836,6 +836,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h755bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755bitx-pinctrl.dtsi
@@ -1058,6 +1058,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h755iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iikx-pinctrl.dtsi
@@ -1030,6 +1030,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h755iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iitx-pinctrl.dtsi
@@ -864,6 +864,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h755xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755xihx-pinctrl.dtsi
@@ -1210,6 +1210,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h755zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755zitx-pinctrl.dtsi
@@ -744,6 +744,238 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h757aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757aiix-pinctrl.dtsi
@@ -836,6 +836,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h757bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757bitx-pinctrl.dtsi
@@ -1022,6 +1022,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h757iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757iitx-pinctrl.dtsi
@@ -836,6 +836,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h757xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757xihx-pinctrl.dtsi
@@ -1210,6 +1210,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
@@ -737,6 +737,243 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_COL */
 
 			/omit-if-no-ref/ eth_col_pa3: eth_col_pa3 {

--- a/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
@@ -873,6 +873,303 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa2: dfsdm2_ckin1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb0: dfsdm2_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb12: dfsdm2_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb13: dfsdm2_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pc10: dfsdm2_ckin0_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pc11: dfsdm2_datin0_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pc12: dfsdm2_ckout_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd10: dfsdm2_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
@@ -919,6 +919,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa2: dfsdm2_ckin1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb0: dfsdm2_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb12: dfsdm2_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb13: dfsdm2_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pc10: dfsdm2_ckin0_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pc11: dfsdm2_datin0_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pc12: dfsdm2_ckout_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd10: dfsdm2_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
@@ -911,6 +911,303 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa2: dfsdm2_ckin1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb0: dfsdm2_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb12: dfsdm2_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb13: dfsdm2_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pc10: dfsdm2_ckin0_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pc11: dfsdm2_datin0_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pc12: dfsdm2_ckout_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd10: dfsdm2_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
@@ -919,6 +919,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa2: dfsdm2_ckin1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb0: dfsdm2_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb12: dfsdm2_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb13: dfsdm2_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pc10: dfsdm2_ckin0_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pc11: dfsdm2_datin0_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pc12: dfsdm2_ckout_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd10: dfsdm2_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
@@ -793,6 +793,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa2: dfsdm2_ckin1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb0: dfsdm2_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb12: dfsdm2_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb13: dfsdm2_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pc10: dfsdm2_ckin0_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pc11: dfsdm2_datin0_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pc12: dfsdm2_ckout_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd10: dfsdm2_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
@@ -1091,6 +1091,303 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa2: dfsdm2_ckin1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb0: dfsdm2_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb12: dfsdm2_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb13: dfsdm2_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pc10: dfsdm2_ckin0_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pc11: dfsdm2_datin0_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pc12: dfsdm2_ckout_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd10: dfsdm2_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
@@ -1031,6 +1031,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa2: dfsdm2_ckin1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb0: dfsdm2_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb12: dfsdm2_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb13: dfsdm2_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pc10: dfsdm2_ckin0_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pc11: dfsdm2_datin0_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pc12: dfsdm2_ckout_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd10: dfsdm2_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7a3qiyxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3qiyxq-pinctrl.dtsi
@@ -656,6 +656,283 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa2: dfsdm2_ckin1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb0: dfsdm2_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb12: dfsdm2_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb13: dfsdm2_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pc10: dfsdm2_ckin0_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pc11: dfsdm2_datin0_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pc12: dfsdm2_ckout_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd10: dfsdm2_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7a3r(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3r(g-i)tx-pinctrl.dtsi
@@ -451,6 +451,173 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa2: dfsdm2_ckin1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb0: dfsdm2_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb12: dfsdm2_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb13: dfsdm2_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pc10: dfsdm2_ckin0_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pc11: dfsdm2_datin0_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pc12: dfsdm2_ckout_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
@@ -598,6 +598,278 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa2: dfsdm2_ckin1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb0: dfsdm2_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb12: dfsdm2_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb13: dfsdm2_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pc10: dfsdm2_ckin0_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pc11: dfsdm2_datin0_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pc12: dfsdm2_ckout_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd10: dfsdm2_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
@@ -578,6 +578,263 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa2: dfsdm2_ckin1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb0: dfsdm2_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb12: dfsdm2_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb13: dfsdm2_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pc10: dfsdm2_ckin0_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pc11: dfsdm2_datin0_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pc12: dfsdm2_ckout_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd10: dfsdm2_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
@@ -598,6 +598,278 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa2: dfsdm2_ckin1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb0: dfsdm2_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb12: dfsdm2_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb13: dfsdm2_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pc10: dfsdm2_ckin0_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pc11: dfsdm2_datin0_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pc12: dfsdm2_ckout_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd10: dfsdm2_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
@@ -540,6 +540,233 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa2: dfsdm2_ckin1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb0: dfsdm2_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb12: dfsdm2_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb13: dfsdm2_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pc10: dfsdm2_ckin0_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pc11: dfsdm2_datin0_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pc12: dfsdm2_ckout_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd10: dfsdm2_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
@@ -765,6 +765,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa2: dfsdm2_ckin1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb0: dfsdm2_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb12: dfsdm2_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb13: dfsdm2_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pc10: dfsdm2_ckin0_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pc11: dfsdm2_datin0_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pc12: dfsdm2_ckout_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd10: dfsdm2_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
@@ -693,6 +693,283 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa2: dfsdm2_ckin1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb0: dfsdm2_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb12: dfsdm2_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb13: dfsdm2_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pc10: dfsdm2_ckin0_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pc11: dfsdm2_datin0_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pc12: dfsdm2_ckout_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd10: dfsdm2_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
@@ -873,6 +873,303 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa2: dfsdm2_ckin1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb0: dfsdm2_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb12: dfsdm2_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb13: dfsdm2_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pc10: dfsdm2_ckin0_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pc11: dfsdm2_datin0_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pc12: dfsdm2_ckout_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd10: dfsdm2_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
@@ -911,6 +911,303 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa2: dfsdm2_ckin1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb0: dfsdm2_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb12: dfsdm2_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb13: dfsdm2_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pc10: dfsdm2_ckin0_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pc11: dfsdm2_datin0_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pc12: dfsdm2_ckout_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd10: dfsdm2_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
@@ -919,6 +919,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa2: dfsdm2_ckin1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb0: dfsdm2_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb12: dfsdm2_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb13: dfsdm2_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pc10: dfsdm2_ckin0_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pc11: dfsdm2_datin0_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pc12: dfsdm2_ckout_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd10: dfsdm2_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b0rbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0rbtx-pinctrl.dtsi
@@ -451,6 +451,173 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa2: dfsdm2_ckin1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb0: dfsdm2_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb12: dfsdm2_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb13: dfsdm2_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pc10: dfsdm2_ckin0_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pc11: dfsdm2_datin0_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pc12: dfsdm2_ckout_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
@@ -598,6 +598,278 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa2: dfsdm2_ckin1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb0: dfsdm2_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb12: dfsdm2_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb13: dfsdm2_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pc10: dfsdm2_ckin0_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pc11: dfsdm2_datin0_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pc12: dfsdm2_ckout_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd10: dfsdm2_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
@@ -765,6 +765,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa2: dfsdm2_ckin1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb0: dfsdm2_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb12: dfsdm2_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb13: dfsdm2_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pc10: dfsdm2_ckin0_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pc11: dfsdm2_datin0_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pc12: dfsdm2_ckout_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd10: dfsdm2_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
@@ -873,6 +873,303 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa2: dfsdm2_ckin1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb0: dfsdm2_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb12: dfsdm2_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb13: dfsdm2_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pc10: dfsdm2_ckin0_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pc11: dfsdm2_datin0_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pc12: dfsdm2_ckout_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd10: dfsdm2_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
@@ -919,6 +919,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa2: dfsdm2_ckin1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb0: dfsdm2_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb12: dfsdm2_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb13: dfsdm2_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pc10: dfsdm2_ckin0_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pc11: dfsdm2_datin0_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pc12: dfsdm2_ckout_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd10: dfsdm2_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
@@ -911,6 +911,303 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa2: dfsdm2_ckin1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb0: dfsdm2_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb12: dfsdm2_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb13: dfsdm2_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pc10: dfsdm2_ckin0_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pc11: dfsdm2_datin0_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pc12: dfsdm2_ckout_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd10: dfsdm2_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
@@ -919,6 +919,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa2: dfsdm2_ckin1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb0: dfsdm2_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb12: dfsdm2_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb13: dfsdm2_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pc10: dfsdm2_ckin0_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pc11: dfsdm2_datin0_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pc12: dfsdm2_ckout_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd10: dfsdm2_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
@@ -793,6 +793,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa2: dfsdm2_ckin1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb0: dfsdm2_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb12: dfsdm2_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb13: dfsdm2_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pc10: dfsdm2_ckin0_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pc11: dfsdm2_datin0_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pc12: dfsdm2_ckout_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd10: dfsdm2_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
@@ -1091,6 +1091,303 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa2: dfsdm2_ckin1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb0: dfsdm2_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb12: dfsdm2_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb13: dfsdm2_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pc10: dfsdm2_ckin0_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pc11: dfsdm2_datin0_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pc12: dfsdm2_ckout_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd10: dfsdm2_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
@@ -1031,6 +1031,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa2: dfsdm2_ckin1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb0: dfsdm2_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb12: dfsdm2_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb13: dfsdm2_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pc10: dfsdm2_ckin0_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pc11: dfsdm2_datin0_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pc12: dfsdm2_ckout_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd10: dfsdm2_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b3qiyxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3qiyxq-pinctrl.dtsi
@@ -656,6 +656,283 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa2: dfsdm2_ckin1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb0: dfsdm2_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb12: dfsdm2_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb13: dfsdm2_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pc10: dfsdm2_ckin0_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pc11: dfsdm2_datin0_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pc12: dfsdm2_ckout_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd10: dfsdm2_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b3ritx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3ritx-pinctrl.dtsi
@@ -451,6 +451,173 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa2: dfsdm2_ckin1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb0: dfsdm2_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb12: dfsdm2_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb13: dfsdm2_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pc10: dfsdm2_ckin0_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pc11: dfsdm2_datin0_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pc12: dfsdm2_ckout_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
@@ -598,6 +598,278 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa2: dfsdm2_ckin1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb0: dfsdm2_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb12: dfsdm2_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb13: dfsdm2_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pc10: dfsdm2_ckin0_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pc11: dfsdm2_datin0_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pc12: dfsdm2_ckout_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd10: dfsdm2_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
@@ -578,6 +578,263 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa2: dfsdm2_ckin1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb0: dfsdm2_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb12: dfsdm2_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb13: dfsdm2_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pc10: dfsdm2_ckin0_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pc11: dfsdm2_datin0_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pc12: dfsdm2_ckout_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd10: dfsdm2_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
@@ -598,6 +598,278 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa2: dfsdm2_ckin1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb0: dfsdm2_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb12: dfsdm2_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb13: dfsdm2_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pc10: dfsdm2_ckin0_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pc11: dfsdm2_datin0_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pc12: dfsdm2_ckout_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd10: dfsdm2_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
@@ -540,6 +540,233 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa2: dfsdm2_ckin1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb0: dfsdm2_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb12: dfsdm2_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb13: dfsdm2_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pc10: dfsdm2_ckin0_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pc11: dfsdm2_datin0_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pc12: dfsdm2_ckout_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd10: dfsdm2_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
@@ -765,6 +765,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa2: dfsdm2_ckin1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb0: dfsdm2_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb12: dfsdm2_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb13: dfsdm2_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pc10: dfsdm2_ckin0_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pc11: dfsdm2_datin0_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pc12: dfsdm2_ckout_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd10: dfsdm2_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
@@ -693,6 +693,283 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2_c: dfsdm1_ckin1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2_c: dfsdm1_ckout_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3_c: dfsdm1_datin1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pa2: dfsdm2_ckin1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pa7: dfsdm2_datin1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pb0: dfsdm2_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin1_pb12: dfsdm2_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin1_pb13: dfsdm2_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckin0_pc10: dfsdm2_ckin0_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_datin0_pc11: dfsdm2_datin0_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pc12: dfsdm2_ckout_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm2_ckout_pd10: dfsdm2_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7r3a8ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3a8ix-pinctrl.dtsi
@@ -1477,6 +1477,16 @@
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
 			};
 
+			/* RCC_MCO */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+			};
+
+			/omit-if-no-ref/ rcc_mco_2_pc9: rcc_mco_2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF0)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7r3i8kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3i8kx-pinctrl.dtsi
@@ -1555,6 +1555,16 @@
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
 			};
 
+			/* RCC_MCO */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+			};
+
+			/omit-if-no-ref/ rcc_mco_2_pc9: rcc_mco_2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF0)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7r3i8tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3i8tx-pinctrl.dtsi
@@ -1519,6 +1519,16 @@
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
 			};
 
+			/* RCC_MCO */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+			};
+
+			/omit-if-no-ref/ rcc_mco_2_pc9: rcc_mco_2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF0)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7r3l8hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3l8hx-pinctrl.dtsi
@@ -1878,6 +1878,16 @@
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
 			};
 
+			/* RCC_MCO */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+			};
+
+			/omit-if-no-ref/ rcc_mco_2_pc9: rcc_mco_2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF0)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7r3l8hxh-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3l8hxh-pinctrl.dtsi
@@ -1786,6 +1786,16 @@
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
 			};
 
+			/* RCC_MCO */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+			};
+
+			/omit-if-no-ref/ rcc_mco_2_pc9: rcc_mco_2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF0)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7r3r8vx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3r8vx-pinctrl.dtsi
@@ -628,6 +628,12 @@
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
 			};
 
+			/* RCC_MCO */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/h7/stm32h7r3v8hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3v8hx-pinctrl.dtsi
@@ -792,6 +792,12 @@
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
 			};
 
+			/* RCC_MCO */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {

--- a/dts/st/h7/stm32h7r3v8tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3v8tx-pinctrl.dtsi
@@ -833,6 +833,12 @@
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
 			};
 
+			/* RCC_MCO */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {

--- a/dts/st/h7/stm32h7r3v8yx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3v8yx-pinctrl.dtsi
@@ -783,6 +783,12 @@
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
 			};
 
+			/* RCC_MCO */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {

--- a/dts/st/h7/stm32h7r3z8jx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3z8jx-pinctrl.dtsi
@@ -1222,6 +1222,16 @@
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
 			};
 
+			/* RCC_MCO */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+			};
+
+			/omit-if-no-ref/ rcc_mco_2_pc9: rcc_mco_2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF0)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7r3z8tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3z8tx-pinctrl.dtsi
@@ -1282,6 +1282,16 @@
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
 			};
 
+			/* RCC_MCO */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+			};
+
+			/omit-if-no-ref/ rcc_mco_2_pc9: rcc_mco_2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF0)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7r7a8ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r7a8ix-pinctrl.dtsi
@@ -1689,6 +1689,16 @@
 				pinmux = <STM32_PINMUX('G', 2, AF13)>;
 			};
 
+			/* RCC_MCO */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+			};
+
+			/omit-if-no-ref/ rcc_mco_2_pc9: rcc_mco_2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF0)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7r7i8kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r7i8kx-pinctrl.dtsi
@@ -1758,6 +1758,16 @@
 				pinmux = <STM32_PINMUX('G', 2, AF13)>;
 			};
 
+			/* RCC_MCO */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+			};
+
+			/omit-if-no-ref/ rcc_mco_2_pc9: rcc_mco_2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF0)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7r7i8tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r7i8tx-pinctrl.dtsi
@@ -1697,6 +1697,16 @@
 				pinmux = <STM32_PINMUX('G', 2, AF13)>;
 			};
 
+			/* RCC_MCO */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+			};
+
+			/omit-if-no-ref/ rcc_mco_2_pc9: rcc_mco_2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF0)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7r7l8hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r7l8hx-pinctrl.dtsi
@@ -2076,6 +2076,16 @@
 				pinmux = <STM32_PINMUX('G', 14, AF13)>;
 			};
 
+			/* RCC_MCO */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+			};
+
+			/omit-if-no-ref/ rcc_mco_2_pc9: rcc_mco_2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF0)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7r7l8hxh-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r7l8hxh-pinctrl.dtsi
@@ -1968,6 +1968,16 @@
 				pinmux = <STM32_PINMUX('G', 14, AF13)>;
 			};
 
+			/* RCC_MCO */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+			};
+
+			/omit-if-no-ref/ rcc_mco_2_pc9: rcc_mco_2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF0)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7r7z8jx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r7z8jx-pinctrl.dtsi
@@ -1385,6 +1385,16 @@
 				pinmux = <STM32_PINMUX('G', 1, AF13)>;
 			};
 
+			/* RCC_MCO */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+			};
+
+			/omit-if-no-ref/ rcc_mco_2_pc9: rcc_mco_2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF0)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {

--- a/dts/st/h7/stm32h7s3a8ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3a8ix-pinctrl.dtsi
@@ -1477,6 +1477,16 @@
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
 			};
 
+			/* RCC_MCO */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+			};
+
+			/omit-if-no-ref/ rcc_mco_2_pc9: rcc_mco_2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF0)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7s3i8kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3i8kx-pinctrl.dtsi
@@ -1555,6 +1555,16 @@
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
 			};
 
+			/* RCC_MCO */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+			};
+
+			/omit-if-no-ref/ rcc_mco_2_pc9: rcc_mco_2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF0)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7s3i8tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3i8tx-pinctrl.dtsi
@@ -1519,6 +1519,16 @@
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
 			};
 
+			/* RCC_MCO */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+			};
+
+			/omit-if-no-ref/ rcc_mco_2_pc9: rcc_mco_2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF0)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7s3l8hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3l8hx-pinctrl.dtsi
@@ -1878,6 +1878,16 @@
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
 			};
 
+			/* RCC_MCO */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+			};
+
+			/omit-if-no-ref/ rcc_mco_2_pc9: rcc_mco_2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF0)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7s3l8hxh-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3l8hxh-pinctrl.dtsi
@@ -1786,6 +1786,16 @@
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
 			};
 
+			/* RCC_MCO */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+			};
+
+			/omit-if-no-ref/ rcc_mco_2_pc9: rcc_mco_2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF0)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7s3r8vx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3r8vx-pinctrl.dtsi
@@ -628,6 +628,12 @@
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
 			};
 
+			/* RCC_MCO */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/h7/stm32h7s3v8hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3v8hx-pinctrl.dtsi
@@ -792,6 +792,12 @@
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
 			};
 
+			/* RCC_MCO */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {

--- a/dts/st/h7/stm32h7s3v8tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3v8tx-pinctrl.dtsi
@@ -833,6 +833,12 @@
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
 			};
 
+			/* RCC_MCO */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {

--- a/dts/st/h7/stm32h7s3v8yx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3v8yx-pinctrl.dtsi
@@ -783,6 +783,12 @@
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
 			};
 
+			/* RCC_MCO */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {

--- a/dts/st/h7/stm32h7s3z8jx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3z8jx-pinctrl.dtsi
@@ -1222,6 +1222,16 @@
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
 			};
 
+			/* RCC_MCO */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+			};
+
+			/omit-if-no-ref/ rcc_mco_2_pc9: rcc_mco_2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF0)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7s3z8tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3z8tx-pinctrl.dtsi
@@ -1282,6 +1282,16 @@
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
 			};
 
+			/* RCC_MCO */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+			};
+
+			/omit-if-no-ref/ rcc_mco_2_pc9: rcc_mco_2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF0)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7s7a8ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s7a8ix-pinctrl.dtsi
@@ -1689,6 +1689,16 @@
 				pinmux = <STM32_PINMUX('G', 2, AF13)>;
 			};
 
+			/* RCC_MCO */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+			};
+
+			/omit-if-no-ref/ rcc_mco_2_pc9: rcc_mco_2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF0)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7s7i8kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s7i8kx-pinctrl.dtsi
@@ -1758,6 +1758,16 @@
 				pinmux = <STM32_PINMUX('G', 2, AF13)>;
 			};
 
+			/* RCC_MCO */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+			};
+
+			/omit-if-no-ref/ rcc_mco_2_pc9: rcc_mco_2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF0)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7s7i8tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s7i8tx-pinctrl.dtsi
@@ -1697,6 +1697,16 @@
 				pinmux = <STM32_PINMUX('G', 2, AF13)>;
 			};
 
+			/* RCC_MCO */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+			};
+
+			/omit-if-no-ref/ rcc_mco_2_pc9: rcc_mco_2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF0)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7s7l8hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s7l8hx-pinctrl.dtsi
@@ -2076,6 +2076,16 @@
 				pinmux = <STM32_PINMUX('G', 14, AF13)>;
 			};
 
+			/* RCC_MCO */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+			};
+
+			/omit-if-no-ref/ rcc_mco_2_pc9: rcc_mco_2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF0)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7s7l8hxh-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s7l8hxh-pinctrl.dtsi
@@ -1968,6 +1968,16 @@
 				pinmux = <STM32_PINMUX('G', 14, AF13)>;
 			};
 
+			/* RCC_MCO */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+			};
+
+			/omit-if-no-ref/ rcc_mco_2_pc9: rcc_mco_2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF0)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7s7z8jx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s7z8jx-pinctrl.dtsi
@@ -1385,6 +1385,16 @@
 				pinmux = <STM32_PINMUX('G', 1, AF13)>;
 			};
 
+			/* RCC_MCO */
+
+			/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF0)>;
+			};
+
+			/omit-if-no-ref/ rcc_mco_2_pc9: rcc_mco_2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF0)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {

--- a/dts/st/l4/stm32l451c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451c(c-e)ux-pinctrl.dtsi
@@ -252,6 +252,63 @@
 				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa5: dfsdm1_ckout_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa7: dfsdm1_datin0_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa8: dfsdm1_ckin1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa9: dfsdm1_datin1_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb0: dfsdm1_ckin0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l451cetx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451cetx-pinctrl.dtsi
@@ -252,6 +252,63 @@
 				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa5: dfsdm1_ckout_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa7: dfsdm1_datin0_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa8: dfsdm1_ckin1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa9: dfsdm1_datin1_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb0: dfsdm1_ckin0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l451r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451r(c-e)ix-pinctrl.dtsi
@@ -332,6 +332,78 @@
 				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa5: dfsdm1_ckout_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa7: dfsdm1_datin0_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa8: dfsdm1_ckin1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa9: dfsdm1_datin1_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb0: dfsdm1_ckin0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l451r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451r(c-e)tx-pinctrl.dtsi
@@ -332,6 +332,78 @@
 				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa5: dfsdm1_ckout_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa7: dfsdm1_datin0_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa8: dfsdm1_ckin1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa9: dfsdm1_datin1_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb0: dfsdm1_ckin0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l451r(c-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451r(c-e)yx-pinctrl.dtsi
@@ -332,6 +332,78 @@
 				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa5: dfsdm1_ckout_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa7: dfsdm1_datin0_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa8: dfsdm1_ckin1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa9: dfsdm1_datin1_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb0: dfsdm1_ckin0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l451v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451v(c-e)ix-pinctrl.dtsi
@@ -465,6 +465,123 @@
 				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa5: dfsdm1_ckout_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa7: dfsdm1_datin0_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa8: dfsdm1_ckin1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa9: dfsdm1_datin1_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb0: dfsdm1_ckin0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l451v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451v(c-e)tx-pinctrl.dtsi
@@ -465,6 +465,123 @@
 				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa5: dfsdm1_ckout_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa7: dfsdm1_datin0_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa8: dfsdm1_ckin1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa9: dfsdm1_datin1_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb0: dfsdm1_ckin0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l452c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452c(c-e)ux-pinctrl.dtsi
@@ -252,6 +252,63 @@
 				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa5: dfsdm1_ckout_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa7: dfsdm1_datin0_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa8: dfsdm1_ckin1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa9: dfsdm1_datin1_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb0: dfsdm1_ckin0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l452cetx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452cetx-pinctrl.dtsi
@@ -252,6 +252,63 @@
 				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa5: dfsdm1_ckout_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa7: dfsdm1_datin0_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa8: dfsdm1_ckin1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa9: dfsdm1_datin1_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb0: dfsdm1_ckin0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l452cetxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452cetxp-pinctrl.dtsi
@@ -252,6 +252,63 @@
 				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa5: dfsdm1_ckout_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa7: dfsdm1_datin0_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa8: dfsdm1_ckin1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa9: dfsdm1_datin1_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb0: dfsdm1_ckin0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l452r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452r(c-e)ix-pinctrl.dtsi
@@ -332,6 +332,78 @@
 				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa5: dfsdm1_ckout_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa7: dfsdm1_datin0_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa8: dfsdm1_ckin1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa9: dfsdm1_datin1_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb0: dfsdm1_ckin0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l452r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452r(c-e)tx-pinctrl.dtsi
@@ -332,6 +332,78 @@
 				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa5: dfsdm1_ckout_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa7: dfsdm1_datin0_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa8: dfsdm1_ckin1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa9: dfsdm1_datin1_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb0: dfsdm1_ckin0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l452r(c-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452r(c-e)yx-pinctrl.dtsi
@@ -332,6 +332,78 @@
 				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa5: dfsdm1_ckout_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa7: dfsdm1_datin0_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa8: dfsdm1_ckin1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa9: dfsdm1_datin1_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb0: dfsdm1_ckin0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l452retxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452retxp-pinctrl.dtsi
@@ -320,6 +320,78 @@
 				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa5: dfsdm1_ckout_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa7: dfsdm1_datin0_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa8: dfsdm1_ckin1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa9: dfsdm1_datin1_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb0: dfsdm1_ckin0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l452reyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452reyxp-pinctrl.dtsi
@@ -332,6 +332,78 @@
 				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa5: dfsdm1_ckout_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa7: dfsdm1_datin0_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa8: dfsdm1_ckin1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa9: dfsdm1_datin1_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb0: dfsdm1_ckin0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l452v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452v(c-e)ix-pinctrl.dtsi
@@ -465,6 +465,123 @@
 				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa5: dfsdm1_ckout_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa7: dfsdm1_datin0_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa8: dfsdm1_ckin1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa9: dfsdm1_datin1_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb0: dfsdm1_ckin0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l452v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452v(c-e)tx-pinctrl.dtsi
@@ -465,6 +465,123 @@
 				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa5: dfsdm1_ckout_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa7: dfsdm1_datin0_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa8: dfsdm1_ckin1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa9: dfsdm1_datin1_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb0: dfsdm1_ckin0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l462cetx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462cetx-pinctrl.dtsi
@@ -252,6 +252,63 @@
 				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa5: dfsdm1_ckout_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa7: dfsdm1_datin0_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa8: dfsdm1_ckin1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa9: dfsdm1_datin1_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb0: dfsdm1_ckin0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l462ceux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462ceux-pinctrl.dtsi
@@ -252,6 +252,63 @@
 				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa5: dfsdm1_ckout_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa7: dfsdm1_datin0_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa8: dfsdm1_ckin1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa9: dfsdm1_datin1_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb0: dfsdm1_ckin0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l462reix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462reix-pinctrl.dtsi
@@ -332,6 +332,78 @@
 				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa5: dfsdm1_ckout_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa7: dfsdm1_datin0_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa8: dfsdm1_ckin1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa9: dfsdm1_datin1_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb0: dfsdm1_ckin0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l462retx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462retx-pinctrl.dtsi
@@ -332,6 +332,78 @@
 				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa5: dfsdm1_ckout_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa7: dfsdm1_datin0_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa8: dfsdm1_ckin1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa9: dfsdm1_datin1_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb0: dfsdm1_ckin0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l462reyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462reyx-pinctrl.dtsi
@@ -332,6 +332,78 @@
 				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa5: dfsdm1_ckout_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa7: dfsdm1_datin0_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa8: dfsdm1_ckin1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa9: dfsdm1_datin1_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb0: dfsdm1_ckin0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l462veix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462veix-pinctrl.dtsi
@@ -465,6 +465,123 @@
 				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa5: dfsdm1_ckout_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa7: dfsdm1_datin0_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa8: dfsdm1_ckin1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa9: dfsdm1_datin1_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb0: dfsdm1_ckin0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l462vetx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462vetx-pinctrl.dtsi
@@ -465,6 +465,123 @@
 				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pa5: dfsdm1_ckout_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa7: dfsdm1_datin0_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa8: dfsdm1_ckin1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pa9: dfsdm1_datin1_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb0: dfsdm1_ckin0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l471q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471q(e-g)ix-pinctrl.dtsi
@@ -647,6 +647,178 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l471r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471r(e-g)tx-pinctrl.dtsi
@@ -394,6 +394,93 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l471v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471v(e-g)tx-pinctrl.dtsi
@@ -527,6 +527,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l471z(e-g)jx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471z(e-g)jx-pinctrl.dtsi
@@ -687,6 +687,178 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l471z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471z(e-g)tx-pinctrl.dtsi
@@ -687,6 +687,178 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l475r(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l475r(c-e-g)tx-pinctrl.dtsi
@@ -394,6 +394,93 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l475v(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l475v(c-e-g)tx-pinctrl.dtsi
@@ -527,6 +527,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l476j(e-g)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476j(e-g)yx-pinctrl.dtsi
@@ -418,6 +418,93 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l476jgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476jgyxp-pinctrl.dtsi
@@ -402,6 +402,93 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l476m(e-g)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476m(e-g)yx-pinctrl.dtsi
@@ -450,6 +450,118 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l476q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476q(e-g)ix-pinctrl.dtsi
@@ -647,6 +647,178 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l476qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476qgixp-pinctrl.dtsi
@@ -647,6 +647,178 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l476r(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476r(c-e-g)tx-pinctrl.dtsi
@@ -394,6 +394,93 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l476v(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476v(c-e-g)tx-pinctrl.dtsi
@@ -527,6 +527,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l476vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476vgyxp-pinctrl.dtsi
@@ -446,6 +446,103 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l476z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476z(e-g)tx-pinctrl.dtsi
@@ -687,6 +687,178 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l476zgjx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476zgjx-pinctrl.dtsi
@@ -687,6 +687,178 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l476zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476zgtxp-pinctrl.dtsi
@@ -679,6 +679,173 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l485j(c-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l485j(c-e)yx-pinctrl.dtsi
@@ -418,6 +418,93 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l486jgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486jgyx-pinctrl.dtsi
@@ -418,6 +418,93 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l486qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486qgix-pinctrl.dtsi
@@ -647,6 +647,178 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l486rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486rgtx-pinctrl.dtsi
@@ -394,6 +394,93 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l486vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486vgtx-pinctrl.dtsi
@@ -527,6 +527,168 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l486zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486zgtx-pinctrl.dtsi
@@ -687,6 +687,178 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l496a(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496a(e-g)ix-pinctrl.dtsi
@@ -948,6 +948,178 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l496agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496agixp-pinctrl.dtsi
@@ -935,6 +935,178 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l496q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496q(e-g)ix-pinctrl.dtsi
@@ -776,6 +776,178 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l496qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496qgixp-pinctrl.dtsi
@@ -768,6 +768,173 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l496qgixs-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496qgixs-pinctrl.dtsi
@@ -776,6 +776,178 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l496r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496r(e-g)tx-pinctrl.dtsi
@@ -483,6 +483,93 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l496rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496rgtxp-pinctrl.dtsi
@@ -467,6 +467,93 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l496v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496v(e-g)tx-pinctrl.dtsi
@@ -656,6 +656,168 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l496vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgtxp-pinctrl.dtsi
@@ -643,6 +643,163 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l496vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgyx-pinctrl.dtsi
@@ -633,6 +633,163 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l496vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgyxp-pinctrl.dtsi
@@ -621,6 +621,163 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l496wgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496wgyxp-pinctrl.dtsi
@@ -659,6 +659,153 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l496z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496z(e-g)tx-pinctrl.dtsi
@@ -816,6 +816,178 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l496zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496zgtxp-pinctrl.dtsi
@@ -808,6 +808,173 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4a6agix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6agix-pinctrl.dtsi
@@ -948,6 +948,178 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4a6agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6agixp-pinctrl.dtsi
@@ -935,6 +935,178 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4a6qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6qgix-pinctrl.dtsi
@@ -776,6 +776,178 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4a6qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6qgixp-pinctrl.dtsi
@@ -768,6 +768,173 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4a6rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6rgtx-pinctrl.dtsi
@@ -483,6 +483,93 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4a6rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6rgtxp-pinctrl.dtsi
@@ -467,6 +467,93 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4a6vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgtx-pinctrl.dtsi
@@ -656,6 +656,168 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4a6vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgtxp-pinctrl.dtsi
@@ -643,6 +643,163 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4a6vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgyx-pinctrl.dtsi
@@ -633,6 +633,163 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4a6vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgyxp-pinctrl.dtsi
@@ -621,6 +621,163 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4a6zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6zgtx-pinctrl.dtsi
@@ -816,6 +816,178 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4a6zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6zgtxp-pinctrl.dtsi
@@ -808,6 +808,173 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4p5a(g-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5a(g-e)ix-pinctrl.dtsi
@@ -908,6 +908,113 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf10: dfsdm1_ckout_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4p5agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5agixp-pinctrl.dtsi
@@ -895,6 +895,113 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf10: dfsdm1_ckout_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4p5c(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5c(g-e)tx-pinctrl.dtsi
@@ -278,6 +278,43 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4p5c(g-e)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5c(g-e)ux-pinctrl.dtsi
@@ -278,6 +278,43 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4p5cgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5cgtxp-pinctrl.dtsi
@@ -265,6 +265,38 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4p5cguxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5cguxp-pinctrl.dtsi
@@ -265,6 +265,38 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4p5q(g-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5q(g-e)ix-pinctrl.dtsi
@@ -740,6 +740,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4p5qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5qgixp-pinctrl.dtsi
@@ -732,6 +732,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4p5qgixs-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5qgixs-pinctrl.dtsi
@@ -732,6 +732,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4p5r(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5r(g-e)tx-pinctrl.dtsi
@@ -459,6 +459,58 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4p5rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5rgtxp-pinctrl.dtsi
@@ -443,6 +443,58 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4p5v(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5v(g-e)tx-pinctrl.dtsi
@@ -632,6 +632,103 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4p5v(g-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5v(g-e)yx-pinctrl.dtsi
@@ -609,6 +609,98 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4p5vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5vgtxp-pinctrl.dtsi
@@ -619,6 +619,103 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4p5vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5vgyxp-pinctrl.dtsi
@@ -597,6 +597,98 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4p5z(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5z(g-e)tx-pinctrl.dtsi
@@ -760,6 +760,113 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf10: dfsdm1_ckout_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4p5zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5zgtxp-pinctrl.dtsi
@@ -752,6 +752,113 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf10: dfsdm1_ckout_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4q5agix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5agix-pinctrl.dtsi
@@ -908,6 +908,113 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf10: dfsdm1_ckout_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4q5agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5agixp-pinctrl.dtsi
@@ -895,6 +895,113 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf10: dfsdm1_ckout_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4q5cgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cgtx-pinctrl.dtsi
@@ -278,6 +278,43 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4q5cgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cgtxp-pinctrl.dtsi
@@ -265,6 +265,38 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4q5cgux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cgux-pinctrl.dtsi
@@ -278,6 +278,43 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4q5cguxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cguxp-pinctrl.dtsi
@@ -265,6 +265,38 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4q5qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5qgix-pinctrl.dtsi
@@ -740,6 +740,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4q5qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5qgixp-pinctrl.dtsi
@@ -732,6 +732,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4q5rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5rgtx-pinctrl.dtsi
@@ -459,6 +459,58 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4q5rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5rgtxp-pinctrl.dtsi
@@ -443,6 +443,58 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4q5vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgtx-pinctrl.dtsi
@@ -632,6 +632,103 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4q5vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgtxp-pinctrl.dtsi
@@ -619,6 +619,103 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4q5vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgyx-pinctrl.dtsi
@@ -609,6 +609,98 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4q5vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgyxp-pinctrl.dtsi
@@ -597,6 +597,98 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4q5zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5zgtx-pinctrl.dtsi
@@ -760,6 +760,113 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf10: dfsdm1_ckout_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4q5zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5zgtxp-pinctrl.dtsi
@@ -752,6 +752,113 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf10: dfsdm1_ckout_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4r5a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5a(g-i)ix-pinctrl.dtsi
@@ -839,6 +839,193 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf10: dfsdm1_ckout_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4r5aiixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5aiixp-pinctrl.dtsi
@@ -839,6 +839,193 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf10: dfsdm1_ckout_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4r5q(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5q(g-i)ix-pinctrl.dtsi
@@ -671,6 +671,188 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4r5qgixs-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5qgixs-pinctrl.dtsi
@@ -671,6 +671,188 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4r5qiixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5qiixp-pinctrl.dtsi
@@ -671,6 +671,188 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4r5v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5v(g-i)tx-pinctrl.dtsi
@@ -563,6 +563,173 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4r5z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5z(g-i)tx-pinctrl.dtsi
@@ -691,6 +691,193 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf10: dfsdm1_ckout_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4r5z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5z(g-i)yx-pinctrl.dtsi
@@ -671,6 +671,193 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf10: dfsdm1_ckout_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4r5zitxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5zitxp-pinctrl.dtsi
@@ -683,6 +683,188 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf10: dfsdm1_ckout_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4r7aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7aiix-pinctrl.dtsi
@@ -839,6 +839,193 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf10: dfsdm1_ckout_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4r7vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7vitx-pinctrl.dtsi
@@ -563,6 +563,173 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4r7zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7zitx-pinctrl.dtsi
@@ -691,6 +691,193 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf10: dfsdm1_ckout_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4r9a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9a(g-i)ix-pinctrl.dtsi
@@ -815,6 +815,193 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf10: dfsdm1_ckout_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4r9v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9v(g-i)tx-pinctrl.dtsi
@@ -525,6 +525,173 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4r9z(g-i)jx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)jx-pinctrl.dtsi
@@ -679,6 +679,193 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf10: dfsdm1_ckout_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4r9z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)tx-pinctrl.dtsi
@@ -667,6 +667,193 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf10: dfsdm1_ckout_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4r9z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)yx-pinctrl.dtsi
@@ -671,6 +671,193 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf10: dfsdm1_ckout_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4r9ziyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9ziyxp-pinctrl.dtsi
@@ -663,6 +663,188 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf10: dfsdm1_ckout_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4s5aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5aiix-pinctrl.dtsi
@@ -839,6 +839,193 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf10: dfsdm1_ckout_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4s5qiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5qiix-pinctrl.dtsi
@@ -671,6 +671,188 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4s5vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5vitx-pinctrl.dtsi
@@ -563,6 +563,173 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4s5zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5zitx-pinctrl.dtsi
@@ -691,6 +691,193 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf10: dfsdm1_ckout_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4s5ziyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5ziyx-pinctrl.dtsi
@@ -671,6 +671,193 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf10: dfsdm1_ckout_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4s7aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7aiix-pinctrl.dtsi
@@ -839,6 +839,193 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf10: dfsdm1_ckout_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4s7vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7vitx-pinctrl.dtsi
@@ -563,6 +563,173 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4s7zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7zitx-pinctrl.dtsi
@@ -691,6 +691,193 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf10: dfsdm1_ckout_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4s9aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9aiix-pinctrl.dtsi
@@ -815,6 +815,193 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf10: dfsdm1_ckout_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4s9vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9vitx-pinctrl.dtsi
@@ -525,6 +525,173 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4s9zijx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9zijx-pinctrl.dtsi
@@ -679,6 +679,193 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf10: dfsdm1_ckout_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4s9zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9zitx-pinctrl.dtsi
@@ -667,6 +667,193 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf10: dfsdm1_ckout_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l4/stm32l4s9ziyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9ziyx-pinctrl.dtsi
@@ -671,6 +671,193 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pb8: dfsdm1_datin6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pb9: dfsdm1_ckin6_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf10: dfsdm1_ckout_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/l5/stm32l552c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552c(c-e)tx-pinctrl.dtsi
@@ -256,6 +256,43 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/l5/stm32l552c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552c(c-e)ux-pinctrl.dtsi
@@ -256,6 +256,43 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/l5/stm32l552cetxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552cetxp-pinctrl.dtsi
@@ -248,6 +248,43 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/l5/stm32l552ceuxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552ceuxp-pinctrl.dtsi
@@ -248,6 +248,43 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/l5/stm32l552meyxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552meyxp-pinctrl.dtsi
@@ -388,6 +388,58 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/l5/stm32l552meyxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552meyxq-pinctrl.dtsi
@@ -376,6 +376,58 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/l5/stm32l552q(c-e)ixq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552q(c-e)ixq-pinctrl.dtsi
@@ -576,6 +576,108 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/l5/stm32l552qeix-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552qeix-pinctrl.dtsi
@@ -592,6 +592,108 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/l5/stm32l552qeixp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552qeixp-pinctrl.dtsi
@@ -584,6 +584,108 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/l5/stm32l552r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552r(c-e)tx-pinctrl.dtsi
@@ -360,6 +360,58 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/l5/stm32l552retxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552retxp-pinctrl.dtsi
@@ -344,6 +344,58 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/l5/stm32l552retxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552retxq-pinctrl.dtsi
@@ -324,6 +324,53 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/l5/stm32l552v(c-e)txq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552v(c-e)txq-pinctrl.dtsi
@@ -452,6 +452,98 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/l5/stm32l552vetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552vetx-pinctrl.dtsi
@@ -484,6 +484,103 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/l5/stm32l552z(c-e)txq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552z(c-e)txq-pinctrl.dtsi
@@ -580,6 +580,108 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf10: dfsdm1_ckout_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/l5/stm32l552zetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552zetx-pinctrl.dtsi
@@ -612,6 +612,113 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf10: dfsdm1_ckout_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/l5/stm32l562cetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562cetx-pinctrl.dtsi
@@ -256,6 +256,43 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/l5/stm32l562cetxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562cetxp-pinctrl.dtsi
@@ -248,6 +248,43 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/l5/stm32l562ceux-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562ceux-pinctrl.dtsi
@@ -256,6 +256,43 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/l5/stm32l562ceuxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562ceuxp-pinctrl.dtsi
@@ -248,6 +248,43 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/l5/stm32l562meyxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562meyxp-pinctrl.dtsi
@@ -388,6 +388,58 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/l5/stm32l562meyxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562meyxq-pinctrl.dtsi
@@ -376,6 +376,58 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/l5/stm32l562qeix-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeix-pinctrl.dtsi
@@ -592,6 +592,108 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/l5/stm32l562qeixp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeixp-pinctrl.dtsi
@@ -584,6 +584,108 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/l5/stm32l562qeixq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeixq-pinctrl.dtsi
@@ -576,6 +576,108 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/l5/stm32l562retx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retx-pinctrl.dtsi
@@ -360,6 +360,58 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/l5/stm32l562retxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retxp-pinctrl.dtsi
@@ -344,6 +344,58 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/l5/stm32l562retxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retxq-pinctrl.dtsi
@@ -324,6 +324,53 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/l5/stm32l562vetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562vetx-pinctrl.dtsi
@@ -484,6 +484,103 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/l5/stm32l562vetxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562vetxq-pinctrl.dtsi
@@ -452,6 +452,98 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/l5/stm32l562zetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562zetx-pinctrl.dtsi
@@ -612,6 +612,113 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf10: dfsdm1_ckout_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/l5/stm32l562zetxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562zetxq-pinctrl.dtsi
@@ -580,6 +580,108 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_datin0_pb1: dfsdm1_datin0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pb2: dfsdm1_ckin0_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb8: dfsdm1_ckout_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf10: dfsdm1_ckout_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pg7: dfsdm1_ckout_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp131aaex-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp131aaex-pinctrl.dtsi
@@ -626,6 +626,148 @@
 				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pa1: dfsdm1_ckin0_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa4: dfsdm1_ckin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa9: dfsdm1_datin0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb8: dfsdm1_datin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc3: dfsdm1_ckout_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc6: dfsdm1_datin0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pd15: dfsdm1_datin2_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf0: dfsdm1_ckout_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pf2: dfsdm1_ckin1_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pf5: dfsdm1_ckin0_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf9: dfsdm1_ckin3_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf11: dfsdm1_ckin3_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pg4: dfsdm1_ckin3_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph10: dfsdm1_datin2_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_ph12: dfsdm1_ckin1_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph14: dfsdm1_datin2_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_a21_pa8: fmc_a21_pa8 {

--- a/dts/st/mp1/stm32mp131aafx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp131aafx-pinctrl.dtsi
@@ -626,6 +626,148 @@
 				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pa1: dfsdm1_ckin0_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa4: dfsdm1_ckin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa9: dfsdm1_datin0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb8: dfsdm1_datin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc3: dfsdm1_ckout_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc6: dfsdm1_datin0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pd15: dfsdm1_datin2_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf0: dfsdm1_ckout_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pf2: dfsdm1_ckin1_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pf5: dfsdm1_ckin0_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf9: dfsdm1_ckin3_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf11: dfsdm1_ckin3_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pg4: dfsdm1_ckin3_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph10: dfsdm1_datin2_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_ph12: dfsdm1_ckin1_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph14: dfsdm1_datin2_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_a21_pa8: fmc_a21_pa8 {

--- a/dts/st/mp1/stm32mp131aagx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp131aagx-pinctrl.dtsi
@@ -626,6 +626,148 @@
 				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pa1: dfsdm1_ckin0_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa4: dfsdm1_ckin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa9: dfsdm1_datin0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb8: dfsdm1_datin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc3: dfsdm1_ckout_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc6: dfsdm1_datin0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pd15: dfsdm1_datin2_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf0: dfsdm1_ckout_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pf2: dfsdm1_ckin1_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pf5: dfsdm1_ckin0_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf9: dfsdm1_ckin3_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf11: dfsdm1_ckin3_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pg4: dfsdm1_ckin3_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph10: dfsdm1_datin2_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_ph12: dfsdm1_ckin1_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph14: dfsdm1_datin2_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_a21_pa8: fmc_a21_pa8 {

--- a/dts/st/mp1/stm32mp131caex-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp131caex-pinctrl.dtsi
@@ -626,6 +626,148 @@
 				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pa1: dfsdm1_ckin0_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa4: dfsdm1_ckin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa9: dfsdm1_datin0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb8: dfsdm1_datin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc3: dfsdm1_ckout_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc6: dfsdm1_datin0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pd15: dfsdm1_datin2_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf0: dfsdm1_ckout_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pf2: dfsdm1_ckin1_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pf5: dfsdm1_ckin0_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf9: dfsdm1_ckin3_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf11: dfsdm1_ckin3_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pg4: dfsdm1_ckin3_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph10: dfsdm1_datin2_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_ph12: dfsdm1_ckin1_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph14: dfsdm1_datin2_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_a21_pa8: fmc_a21_pa8 {

--- a/dts/st/mp1/stm32mp131cafx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp131cafx-pinctrl.dtsi
@@ -626,6 +626,148 @@
 				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pa1: dfsdm1_ckin0_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa4: dfsdm1_ckin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa9: dfsdm1_datin0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb8: dfsdm1_datin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc3: dfsdm1_ckout_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc6: dfsdm1_datin0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pd15: dfsdm1_datin2_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf0: dfsdm1_ckout_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pf2: dfsdm1_ckin1_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pf5: dfsdm1_ckin0_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf9: dfsdm1_ckin3_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf11: dfsdm1_ckin3_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pg4: dfsdm1_ckin3_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph10: dfsdm1_datin2_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_ph12: dfsdm1_ckin1_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph14: dfsdm1_datin2_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_a21_pa8: fmc_a21_pa8 {

--- a/dts/st/mp1/stm32mp131cagx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp131cagx-pinctrl.dtsi
@@ -626,6 +626,148 @@
 				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pa1: dfsdm1_ckin0_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa4: dfsdm1_ckin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa9: dfsdm1_datin0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb8: dfsdm1_datin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc3: dfsdm1_ckout_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc6: dfsdm1_datin0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pd15: dfsdm1_datin2_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf0: dfsdm1_ckout_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pf2: dfsdm1_ckin1_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pf5: dfsdm1_ckin0_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf9: dfsdm1_ckin3_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf11: dfsdm1_ckin3_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pg4: dfsdm1_ckin3_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph10: dfsdm1_datin2_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_ph12: dfsdm1_ckin1_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph14: dfsdm1_datin2_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_a21_pa8: fmc_a21_pa8 {

--- a/dts/st/mp1/stm32mp131daex-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp131daex-pinctrl.dtsi
@@ -626,6 +626,148 @@
 				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pa1: dfsdm1_ckin0_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa4: dfsdm1_ckin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa9: dfsdm1_datin0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb8: dfsdm1_datin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc3: dfsdm1_ckout_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc6: dfsdm1_datin0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pd15: dfsdm1_datin2_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf0: dfsdm1_ckout_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pf2: dfsdm1_ckin1_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pf5: dfsdm1_ckin0_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf9: dfsdm1_ckin3_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf11: dfsdm1_ckin3_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pg4: dfsdm1_ckin3_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph10: dfsdm1_datin2_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_ph12: dfsdm1_ckin1_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph14: dfsdm1_datin2_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_a21_pa8: fmc_a21_pa8 {

--- a/dts/st/mp1/stm32mp131dafx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp131dafx-pinctrl.dtsi
@@ -626,6 +626,148 @@
 				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pa1: dfsdm1_ckin0_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa4: dfsdm1_ckin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa9: dfsdm1_datin0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb8: dfsdm1_datin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc3: dfsdm1_ckout_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc6: dfsdm1_datin0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pd15: dfsdm1_datin2_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf0: dfsdm1_ckout_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pf2: dfsdm1_ckin1_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pf5: dfsdm1_ckin0_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf9: dfsdm1_ckin3_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf11: dfsdm1_ckin3_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pg4: dfsdm1_ckin3_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph10: dfsdm1_datin2_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_ph12: dfsdm1_ckin1_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph14: dfsdm1_datin2_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_a21_pa8: fmc_a21_pa8 {

--- a/dts/st/mp1/stm32mp131dagx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp131dagx-pinctrl.dtsi
@@ -626,6 +626,148 @@
 				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pa1: dfsdm1_ckin0_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa4: dfsdm1_ckin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa9: dfsdm1_datin0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb8: dfsdm1_datin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc3: dfsdm1_ckout_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc6: dfsdm1_datin0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pd15: dfsdm1_datin2_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf0: dfsdm1_ckout_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pf2: dfsdm1_ckin1_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pf5: dfsdm1_ckin0_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf9: dfsdm1_ckin3_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf11: dfsdm1_ckin3_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pg4: dfsdm1_ckin3_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph10: dfsdm1_datin2_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_ph12: dfsdm1_ckin1_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph14: dfsdm1_datin2_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_a21_pa8: fmc_a21_pa8 {

--- a/dts/st/mp1/stm32mp131faex-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp131faex-pinctrl.dtsi
@@ -626,6 +626,148 @@
 				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pa1: dfsdm1_ckin0_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa4: dfsdm1_ckin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa9: dfsdm1_datin0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb8: dfsdm1_datin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc3: dfsdm1_ckout_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc6: dfsdm1_datin0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pd15: dfsdm1_datin2_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf0: dfsdm1_ckout_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pf2: dfsdm1_ckin1_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pf5: dfsdm1_ckin0_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf9: dfsdm1_ckin3_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf11: dfsdm1_ckin3_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pg4: dfsdm1_ckin3_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph10: dfsdm1_datin2_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_ph12: dfsdm1_ckin1_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph14: dfsdm1_datin2_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_a21_pa8: fmc_a21_pa8 {

--- a/dts/st/mp1/stm32mp131fafx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp131fafx-pinctrl.dtsi
@@ -626,6 +626,148 @@
 				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pa1: dfsdm1_ckin0_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa4: dfsdm1_ckin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa9: dfsdm1_datin0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb8: dfsdm1_datin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc3: dfsdm1_ckout_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc6: dfsdm1_datin0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pd15: dfsdm1_datin2_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf0: dfsdm1_ckout_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pf2: dfsdm1_ckin1_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pf5: dfsdm1_ckin0_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf9: dfsdm1_ckin3_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf11: dfsdm1_ckin3_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pg4: dfsdm1_ckin3_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph10: dfsdm1_datin2_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_ph12: dfsdm1_ckin1_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph14: dfsdm1_datin2_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_a21_pa8: fmc_a21_pa8 {

--- a/dts/st/mp1/stm32mp131fagx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp131fagx-pinctrl.dtsi
@@ -626,6 +626,148 @@
 				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pa1: dfsdm1_ckin0_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa4: dfsdm1_ckin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa9: dfsdm1_datin0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb8: dfsdm1_datin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc3: dfsdm1_ckout_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc6: dfsdm1_datin0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pd15: dfsdm1_datin2_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf0: dfsdm1_ckout_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pf2: dfsdm1_ckin1_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pf5: dfsdm1_ckin0_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf9: dfsdm1_ckin3_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf11: dfsdm1_ckin3_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pg4: dfsdm1_ckin3_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph10: dfsdm1_datin2_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_ph12: dfsdm1_ckin1_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph14: dfsdm1_datin2_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_a21_pa8: fmc_a21_pa8 {

--- a/dts/st/mp1/stm32mp133aaex-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp133aaex-pinctrl.dtsi
@@ -734,6 +734,148 @@
 				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pa1: dfsdm1_ckin0_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa4: dfsdm1_ckin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa9: dfsdm1_datin0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb8: dfsdm1_datin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc3: dfsdm1_ckout_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc6: dfsdm1_datin0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pd15: dfsdm1_datin2_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf0: dfsdm1_ckout_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pf2: dfsdm1_ckin1_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pf5: dfsdm1_ckin0_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf9: dfsdm1_ckin3_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf11: dfsdm1_ckin3_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pg4: dfsdm1_ckin3_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph10: dfsdm1_datin2_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_ph12: dfsdm1_ckin1_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph14: dfsdm1_datin2_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp1/stm32mp133aafx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp133aafx-pinctrl.dtsi
@@ -734,6 +734,148 @@
 				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pa1: dfsdm1_ckin0_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa4: dfsdm1_ckin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa9: dfsdm1_datin0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb8: dfsdm1_datin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc3: dfsdm1_ckout_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc6: dfsdm1_datin0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pd15: dfsdm1_datin2_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf0: dfsdm1_ckout_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pf2: dfsdm1_ckin1_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pf5: dfsdm1_ckin0_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf9: dfsdm1_ckin3_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf11: dfsdm1_ckin3_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pg4: dfsdm1_ckin3_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph10: dfsdm1_datin2_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_ph12: dfsdm1_ckin1_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph14: dfsdm1_datin2_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp1/stm32mp133aagx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp133aagx-pinctrl.dtsi
@@ -734,6 +734,148 @@
 				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pa1: dfsdm1_ckin0_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa4: dfsdm1_ckin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa9: dfsdm1_datin0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb8: dfsdm1_datin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc3: dfsdm1_ckout_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc6: dfsdm1_datin0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pd15: dfsdm1_datin2_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf0: dfsdm1_ckout_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pf2: dfsdm1_ckin1_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pf5: dfsdm1_ckin0_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf9: dfsdm1_ckin3_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf11: dfsdm1_ckin3_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pg4: dfsdm1_ckin3_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph10: dfsdm1_datin2_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_ph12: dfsdm1_ckin1_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph14: dfsdm1_datin2_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp1/stm32mp133caex-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp133caex-pinctrl.dtsi
@@ -734,6 +734,148 @@
 				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pa1: dfsdm1_ckin0_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa4: dfsdm1_ckin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa9: dfsdm1_datin0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb8: dfsdm1_datin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc3: dfsdm1_ckout_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc6: dfsdm1_datin0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pd15: dfsdm1_datin2_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf0: dfsdm1_ckout_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pf2: dfsdm1_ckin1_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pf5: dfsdm1_ckin0_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf9: dfsdm1_ckin3_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf11: dfsdm1_ckin3_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pg4: dfsdm1_ckin3_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph10: dfsdm1_datin2_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_ph12: dfsdm1_ckin1_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph14: dfsdm1_datin2_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp1/stm32mp133cafx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp133cafx-pinctrl.dtsi
@@ -734,6 +734,148 @@
 				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pa1: dfsdm1_ckin0_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa4: dfsdm1_ckin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa9: dfsdm1_datin0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb8: dfsdm1_datin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc3: dfsdm1_ckout_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc6: dfsdm1_datin0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pd15: dfsdm1_datin2_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf0: dfsdm1_ckout_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pf2: dfsdm1_ckin1_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pf5: dfsdm1_ckin0_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf9: dfsdm1_ckin3_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf11: dfsdm1_ckin3_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pg4: dfsdm1_ckin3_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph10: dfsdm1_datin2_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_ph12: dfsdm1_ckin1_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph14: dfsdm1_datin2_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp1/stm32mp133cagx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp133cagx-pinctrl.dtsi
@@ -734,6 +734,148 @@
 				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pa1: dfsdm1_ckin0_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa4: dfsdm1_ckin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa9: dfsdm1_datin0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb8: dfsdm1_datin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc3: dfsdm1_ckout_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc6: dfsdm1_datin0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pd15: dfsdm1_datin2_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf0: dfsdm1_ckout_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pf2: dfsdm1_ckin1_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pf5: dfsdm1_ckin0_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf9: dfsdm1_ckin3_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf11: dfsdm1_ckin3_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pg4: dfsdm1_ckin3_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph10: dfsdm1_datin2_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_ph12: dfsdm1_ckin1_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph14: dfsdm1_datin2_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp1/stm32mp133daex-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp133daex-pinctrl.dtsi
@@ -734,6 +734,148 @@
 				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pa1: dfsdm1_ckin0_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa4: dfsdm1_ckin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa9: dfsdm1_datin0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb8: dfsdm1_datin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc3: dfsdm1_ckout_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc6: dfsdm1_datin0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pd15: dfsdm1_datin2_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf0: dfsdm1_ckout_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pf2: dfsdm1_ckin1_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pf5: dfsdm1_ckin0_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf9: dfsdm1_ckin3_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf11: dfsdm1_ckin3_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pg4: dfsdm1_ckin3_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph10: dfsdm1_datin2_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_ph12: dfsdm1_ckin1_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph14: dfsdm1_datin2_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp1/stm32mp133dafx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp133dafx-pinctrl.dtsi
@@ -734,6 +734,148 @@
 				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pa1: dfsdm1_ckin0_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa4: dfsdm1_ckin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa9: dfsdm1_datin0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb8: dfsdm1_datin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc3: dfsdm1_ckout_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc6: dfsdm1_datin0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pd15: dfsdm1_datin2_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf0: dfsdm1_ckout_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pf2: dfsdm1_ckin1_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pf5: dfsdm1_ckin0_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf9: dfsdm1_ckin3_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf11: dfsdm1_ckin3_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pg4: dfsdm1_ckin3_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph10: dfsdm1_datin2_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_ph12: dfsdm1_ckin1_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph14: dfsdm1_datin2_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp1/stm32mp133dagx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp133dagx-pinctrl.dtsi
@@ -734,6 +734,148 @@
 				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pa1: dfsdm1_ckin0_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa4: dfsdm1_ckin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa9: dfsdm1_datin0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb8: dfsdm1_datin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc3: dfsdm1_ckout_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc6: dfsdm1_datin0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pd15: dfsdm1_datin2_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf0: dfsdm1_ckout_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pf2: dfsdm1_ckin1_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pf5: dfsdm1_ckin0_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf9: dfsdm1_ckin3_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf11: dfsdm1_ckin3_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pg4: dfsdm1_ckin3_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph10: dfsdm1_datin2_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_ph12: dfsdm1_ckin1_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph14: dfsdm1_datin2_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp1/stm32mp133faex-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp133faex-pinctrl.dtsi
@@ -734,6 +734,148 @@
 				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pa1: dfsdm1_ckin0_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa4: dfsdm1_ckin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa9: dfsdm1_datin0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb8: dfsdm1_datin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc3: dfsdm1_ckout_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc6: dfsdm1_datin0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pd15: dfsdm1_datin2_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf0: dfsdm1_ckout_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pf2: dfsdm1_ckin1_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pf5: dfsdm1_ckin0_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf9: dfsdm1_ckin3_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf11: dfsdm1_ckin3_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pg4: dfsdm1_ckin3_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph10: dfsdm1_datin2_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_ph12: dfsdm1_ckin1_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph14: dfsdm1_datin2_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp1/stm32mp133fafx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp133fafx-pinctrl.dtsi
@@ -734,6 +734,148 @@
 				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pa1: dfsdm1_ckin0_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa4: dfsdm1_ckin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa9: dfsdm1_datin0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb8: dfsdm1_datin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc3: dfsdm1_ckout_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc6: dfsdm1_datin0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pd15: dfsdm1_datin2_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf0: dfsdm1_ckout_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pf2: dfsdm1_ckin1_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pf5: dfsdm1_ckin0_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf9: dfsdm1_ckin3_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf11: dfsdm1_ckin3_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pg4: dfsdm1_ckin3_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph10: dfsdm1_datin2_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_ph12: dfsdm1_ckin1_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph14: dfsdm1_datin2_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp1/stm32mp133fagx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp133fagx-pinctrl.dtsi
@@ -734,6 +734,148 @@
 				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pa1: dfsdm1_ckin0_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa4: dfsdm1_ckin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa9: dfsdm1_datin0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb8: dfsdm1_datin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc3: dfsdm1_ckout_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc6: dfsdm1_datin0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pd15: dfsdm1_datin2_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf0: dfsdm1_ckout_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pf2: dfsdm1_ckin1_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pf5: dfsdm1_ckin0_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf9: dfsdm1_ckin3_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf11: dfsdm1_ckin3_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pg4: dfsdm1_ckin3_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph10: dfsdm1_datin2_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_ph12: dfsdm1_ckin1_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph14: dfsdm1_datin2_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp1/stm32mp135aaex-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp135aaex-pinctrl.dtsi
@@ -734,6 +734,148 @@
 				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pa1: dfsdm1_ckin0_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa4: dfsdm1_ckin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa9: dfsdm1_datin0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb8: dfsdm1_datin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc3: dfsdm1_ckout_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc6: dfsdm1_datin0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pd15: dfsdm1_datin2_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf0: dfsdm1_ckout_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pf2: dfsdm1_ckin1_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pf5: dfsdm1_ckin0_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf9: dfsdm1_ckin3_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf11: dfsdm1_ckin3_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pg4: dfsdm1_ckin3_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph10: dfsdm1_datin2_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_ph12: dfsdm1_ckin1_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph14: dfsdm1_datin2_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp1/stm32mp135aafx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp135aafx-pinctrl.dtsi
@@ -734,6 +734,148 @@
 				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pa1: dfsdm1_ckin0_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa4: dfsdm1_ckin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa9: dfsdm1_datin0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb8: dfsdm1_datin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc3: dfsdm1_ckout_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc6: dfsdm1_datin0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pd15: dfsdm1_datin2_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf0: dfsdm1_ckout_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pf2: dfsdm1_ckin1_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pf5: dfsdm1_ckin0_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf9: dfsdm1_ckin3_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf11: dfsdm1_ckin3_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pg4: dfsdm1_ckin3_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph10: dfsdm1_datin2_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_ph12: dfsdm1_ckin1_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph14: dfsdm1_datin2_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp1/stm32mp135aagx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp135aagx-pinctrl.dtsi
@@ -734,6 +734,148 @@
 				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pa1: dfsdm1_ckin0_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa4: dfsdm1_ckin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa9: dfsdm1_datin0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb8: dfsdm1_datin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc3: dfsdm1_ckout_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc6: dfsdm1_datin0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pd15: dfsdm1_datin2_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf0: dfsdm1_ckout_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pf2: dfsdm1_ckin1_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pf5: dfsdm1_ckin0_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf9: dfsdm1_ckin3_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf11: dfsdm1_ckin3_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pg4: dfsdm1_ckin3_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph10: dfsdm1_datin2_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_ph12: dfsdm1_ckin1_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph14: dfsdm1_datin2_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp1/stm32mp135caex-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp135caex-pinctrl.dtsi
@@ -734,6 +734,148 @@
 				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pa1: dfsdm1_ckin0_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa4: dfsdm1_ckin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa9: dfsdm1_datin0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb8: dfsdm1_datin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc3: dfsdm1_ckout_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc6: dfsdm1_datin0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pd15: dfsdm1_datin2_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf0: dfsdm1_ckout_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pf2: dfsdm1_ckin1_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pf5: dfsdm1_ckin0_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf9: dfsdm1_ckin3_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf11: dfsdm1_ckin3_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pg4: dfsdm1_ckin3_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph10: dfsdm1_datin2_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_ph12: dfsdm1_ckin1_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph14: dfsdm1_datin2_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp1/stm32mp135cafx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp135cafx-pinctrl.dtsi
@@ -734,6 +734,148 @@
 				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pa1: dfsdm1_ckin0_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa4: dfsdm1_ckin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa9: dfsdm1_datin0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb8: dfsdm1_datin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc3: dfsdm1_ckout_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc6: dfsdm1_datin0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pd15: dfsdm1_datin2_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf0: dfsdm1_ckout_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pf2: dfsdm1_ckin1_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pf5: dfsdm1_ckin0_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf9: dfsdm1_ckin3_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf11: dfsdm1_ckin3_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pg4: dfsdm1_ckin3_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph10: dfsdm1_datin2_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_ph12: dfsdm1_ckin1_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph14: dfsdm1_datin2_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp1/stm32mp135cagx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp135cagx-pinctrl.dtsi
@@ -734,6 +734,148 @@
 				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pa1: dfsdm1_ckin0_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa4: dfsdm1_ckin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa9: dfsdm1_datin0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb8: dfsdm1_datin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc3: dfsdm1_ckout_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc6: dfsdm1_datin0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pd15: dfsdm1_datin2_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf0: dfsdm1_ckout_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pf2: dfsdm1_ckin1_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pf5: dfsdm1_ckin0_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf9: dfsdm1_ckin3_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf11: dfsdm1_ckin3_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pg4: dfsdm1_ckin3_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph10: dfsdm1_datin2_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_ph12: dfsdm1_ckin1_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph14: dfsdm1_datin2_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp1/stm32mp135daex-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp135daex-pinctrl.dtsi
@@ -734,6 +734,148 @@
 				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pa1: dfsdm1_ckin0_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa4: dfsdm1_ckin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa9: dfsdm1_datin0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb8: dfsdm1_datin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc3: dfsdm1_ckout_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc6: dfsdm1_datin0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pd15: dfsdm1_datin2_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf0: dfsdm1_ckout_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pf2: dfsdm1_ckin1_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pf5: dfsdm1_ckin0_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf9: dfsdm1_ckin3_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf11: dfsdm1_ckin3_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pg4: dfsdm1_ckin3_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph10: dfsdm1_datin2_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_ph12: dfsdm1_ckin1_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph14: dfsdm1_datin2_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp1/stm32mp135dafx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp135dafx-pinctrl.dtsi
@@ -734,6 +734,148 @@
 				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pa1: dfsdm1_ckin0_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa4: dfsdm1_ckin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa9: dfsdm1_datin0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb8: dfsdm1_datin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc3: dfsdm1_ckout_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc6: dfsdm1_datin0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pd15: dfsdm1_datin2_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf0: dfsdm1_ckout_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pf2: dfsdm1_ckin1_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pf5: dfsdm1_ckin0_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf9: dfsdm1_ckin3_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf11: dfsdm1_ckin3_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pg4: dfsdm1_ckin3_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph10: dfsdm1_datin2_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_ph12: dfsdm1_ckin1_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph14: dfsdm1_datin2_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp1/stm32mp135dagx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp135dagx-pinctrl.dtsi
@@ -734,6 +734,148 @@
 				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pa1: dfsdm1_ckin0_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa4: dfsdm1_ckin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa9: dfsdm1_datin0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb8: dfsdm1_datin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc3: dfsdm1_ckout_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc6: dfsdm1_datin0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pd15: dfsdm1_datin2_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf0: dfsdm1_ckout_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pf2: dfsdm1_ckin1_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pf5: dfsdm1_ckin0_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf9: dfsdm1_ckin3_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf11: dfsdm1_ckin3_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pg4: dfsdm1_ckin3_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph10: dfsdm1_datin2_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_ph12: dfsdm1_ckin1_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph14: dfsdm1_datin2_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp1/stm32mp135faex-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp135faex-pinctrl.dtsi
@@ -734,6 +734,148 @@
 				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pa1: dfsdm1_ckin0_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa4: dfsdm1_ckin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa9: dfsdm1_datin0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb8: dfsdm1_datin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc3: dfsdm1_ckout_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc6: dfsdm1_datin0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pd15: dfsdm1_datin2_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf0: dfsdm1_ckout_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pf2: dfsdm1_ckin1_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pf5: dfsdm1_ckin0_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf9: dfsdm1_ckin3_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf11: dfsdm1_ckin3_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pg4: dfsdm1_ckin3_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph10: dfsdm1_datin2_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_ph12: dfsdm1_ckin1_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph14: dfsdm1_datin2_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp1/stm32mp135fafx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp135fafx-pinctrl.dtsi
@@ -734,6 +734,148 @@
 				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pa1: dfsdm1_ckin0_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa4: dfsdm1_ckin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa9: dfsdm1_datin0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb8: dfsdm1_datin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc3: dfsdm1_ckout_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc6: dfsdm1_datin0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pd15: dfsdm1_datin2_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf0: dfsdm1_ckout_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pf2: dfsdm1_ckin1_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pf5: dfsdm1_ckin0_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf9: dfsdm1_ckin3_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf11: dfsdm1_ckin3_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pg4: dfsdm1_ckin3_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph10: dfsdm1_datin2_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_ph12: dfsdm1_ckin1_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph14: dfsdm1_datin2_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp1/stm32mp135fagx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp135fagx-pinctrl.dtsi
@@ -734,6 +734,148 @@
 				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pa1: dfsdm1_ckin0_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pa4: dfsdm1_ckin1_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pa9: dfsdm1_datin0_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb8: dfsdm1_datin1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc3: dfsdm1_ckout_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc6: dfsdm1_datin0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pd15: dfsdm1_datin2_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pf0: dfsdm1_ckout_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pf2: dfsdm1_ckin1_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pf5: dfsdm1_ckin0_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf9: dfsdm1_ckin3_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pf11: dfsdm1_ckin3_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pg4: dfsdm1_ckin3_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph10: dfsdm1_datin2_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_ph12: dfsdm1_ckin1_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_ph14: dfsdm1_datin2_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp1/stm32mp151aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aaax-pinctrl.dtsi
@@ -1090,6 +1090,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pg0: dfsdm1_datin0_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pg3: dfsdm1_ckin1_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_ph3: dfsdm1_ckin4_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aabx-pinctrl.dtsi
@@ -708,6 +708,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aacx-pinctrl.dtsi
@@ -978,6 +978,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pg0: dfsdm1_datin0_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pg3: dfsdm1_ckin1_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_ph3: dfsdm1_ckin4_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aadx-pinctrl.dtsi
@@ -708,6 +708,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151caax-pinctrl.dtsi
@@ -1090,6 +1090,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pg0: dfsdm1_datin0_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pg3: dfsdm1_ckin1_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_ph3: dfsdm1_ckin4_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cabx-pinctrl.dtsi
@@ -708,6 +708,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cacx-pinctrl.dtsi
@@ -978,6 +978,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pg0: dfsdm1_datin0_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pg3: dfsdm1_ckin1_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_ph3: dfsdm1_ckin4_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cadx-pinctrl.dtsi
@@ -708,6 +708,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151daax-pinctrl.dtsi
@@ -1090,6 +1090,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pg0: dfsdm1_datin0_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pg3: dfsdm1_ckin1_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_ph3: dfsdm1_ckin4_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dabx-pinctrl.dtsi
@@ -708,6 +708,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dacx-pinctrl.dtsi
@@ -978,6 +978,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pg0: dfsdm1_datin0_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pg3: dfsdm1_ckin1_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_ph3: dfsdm1_ckin4_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dadx-pinctrl.dtsi
@@ -708,6 +708,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151faax-pinctrl.dtsi
@@ -1090,6 +1090,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pg0: dfsdm1_datin0_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pg3: dfsdm1_ckin1_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_ph3: dfsdm1_ckin4_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151fabx-pinctrl.dtsi
@@ -708,6 +708,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151facx-pinctrl.dtsi
@@ -978,6 +978,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pg0: dfsdm1_datin0_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pg3: dfsdm1_ckin1_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_ph3: dfsdm1_ckin4_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151fadx-pinctrl.dtsi
@@ -708,6 +708,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp153aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aaax-pinctrl.dtsi
@@ -1090,6 +1090,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pg0: dfsdm1_datin0_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pg3: dfsdm1_ckin1_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_ph3: dfsdm1_ckin4_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aabx-pinctrl.dtsi
@@ -708,6 +708,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aacx-pinctrl.dtsi
@@ -978,6 +978,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pg0: dfsdm1_datin0_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pg3: dfsdm1_ckin1_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_ph3: dfsdm1_ckin4_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aadx-pinctrl.dtsi
@@ -708,6 +708,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153caax-pinctrl.dtsi
@@ -1090,6 +1090,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pg0: dfsdm1_datin0_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pg3: dfsdm1_ckin1_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_ph3: dfsdm1_ckin4_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cabx-pinctrl.dtsi
@@ -708,6 +708,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cacx-pinctrl.dtsi
@@ -978,6 +978,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pg0: dfsdm1_datin0_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pg3: dfsdm1_ckin1_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_ph3: dfsdm1_ckin4_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cadx-pinctrl.dtsi
@@ -708,6 +708,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153daax-pinctrl.dtsi
@@ -1090,6 +1090,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pg0: dfsdm1_datin0_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pg3: dfsdm1_ckin1_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_ph3: dfsdm1_ckin4_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dabx-pinctrl.dtsi
@@ -708,6 +708,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dacx-pinctrl.dtsi
@@ -978,6 +978,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pg0: dfsdm1_datin0_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pg3: dfsdm1_ckin1_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_ph3: dfsdm1_ckin4_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dadx-pinctrl.dtsi
@@ -708,6 +708,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153faax-pinctrl.dtsi
@@ -1090,6 +1090,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pg0: dfsdm1_datin0_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pg3: dfsdm1_ckin1_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_ph3: dfsdm1_ckin4_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153fabx-pinctrl.dtsi
@@ -708,6 +708,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153facx-pinctrl.dtsi
@@ -978,6 +978,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pg0: dfsdm1_datin0_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pg3: dfsdm1_ckin1_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_ph3: dfsdm1_ckin4_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153fadx-pinctrl.dtsi
@@ -708,6 +708,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aaax-pinctrl.dtsi
@@ -1090,6 +1090,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pg0: dfsdm1_datin0_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pg3: dfsdm1_ckin1_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_ph3: dfsdm1_ckin4_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aabx-pinctrl.dtsi
@@ -708,6 +708,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aacx-pinctrl.dtsi
@@ -978,6 +978,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pg0: dfsdm1_datin0_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pg3: dfsdm1_ckin1_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_ph3: dfsdm1_ckin4_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aadx-pinctrl.dtsi
@@ -708,6 +708,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157caax-pinctrl.dtsi
@@ -1090,6 +1090,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pg0: dfsdm1_datin0_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pg3: dfsdm1_ckin1_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_ph3: dfsdm1_ckin4_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cabx-pinctrl.dtsi
@@ -708,6 +708,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cacx-pinctrl.dtsi
@@ -978,6 +978,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pg0: dfsdm1_datin0_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pg3: dfsdm1_ckin1_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_ph3: dfsdm1_ckin4_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cadx-pinctrl.dtsi
@@ -708,6 +708,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157daax-pinctrl.dtsi
@@ -1090,6 +1090,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pg0: dfsdm1_datin0_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pg3: dfsdm1_ckin1_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_ph3: dfsdm1_ckin4_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dabx-pinctrl.dtsi
@@ -708,6 +708,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dacx-pinctrl.dtsi
@@ -978,6 +978,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pg0: dfsdm1_datin0_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pg3: dfsdm1_ckin1_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_ph3: dfsdm1_ckin4_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dadx-pinctrl.dtsi
@@ -708,6 +708,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157faax-pinctrl.dtsi
@@ -1090,6 +1090,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pg0: dfsdm1_datin0_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pg3: dfsdm1_ckin1_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_ph3: dfsdm1_ckin4_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157fabx-pinctrl.dtsi
@@ -708,6 +708,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157facx-pinctrl.dtsi
@@ -978,6 +978,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pf13: dfsdm1_datin3_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pf13: dfsdm1_datin6_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pf14: dfsdm1_ckin6_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pg0: dfsdm1_datin0_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pg3: dfsdm1_ckin1_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_ph3: dfsdm1_ckin4_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157fadx-pinctrl.dtsi
@@ -708,6 +708,258 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* DFSDM */
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb0: dfsdm1_ckout_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb1: dfsdm1_datin1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb2: dfsdm1_ckin1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pb6: dfsdm1_datin5_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pb7: dfsdm1_ckin5_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb8: dfsdm1_ckin7_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb9: dfsdm1_datin7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pb10: dfsdm1_datin7_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pb11: dfsdm1_ckin7_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pb12: dfsdm1_datin1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pb13: dfsdm1_ckin1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pb13: dfsdm1_ckout_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pb14: dfsdm1_datin2_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pb15: dfsdm1_ckin2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pc0: dfsdm1_ckin0_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pc0: dfsdm1_datin4_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pc1: dfsdm1_ckin4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pc1: dfsdm1_datin0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pc2: dfsdm1_ckin1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pc2: dfsdm1_ckout_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pc3: dfsdm1_datin1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pc4: dfsdm1_ckin2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pc5: dfsdm1_datin2_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pc6: dfsdm1_ckin3_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pc7: dfsdm1_datin3_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pc10: dfsdm1_ckin5_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pc11: dfsdm1_datin5_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin6_pd0: dfsdm1_ckin6_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin7_pd0: dfsdm1_datin7_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin7_pd1: dfsdm1_ckin7_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin6_pd1: dfsdm1_datin6_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd3: dfsdm1_ckout_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin0_pd3: dfsdm1_datin0_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin0_pd4: dfsdm1_ckin0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pd6: dfsdm1_ckin4_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin1_pd6: dfsdm1_datin1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin1_pd7: dfsdm1_ckin1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pd7: dfsdm1_datin4_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pd8: dfsdm1_ckin3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pd9: dfsdm1_datin3_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pd10: dfsdm1_ckout_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin3_pe4: dfsdm1_datin3_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin3_pe5: dfsdm1_ckin3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin2_pe7: dfsdm1_datin2_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin2_pe8: dfsdm1_ckin2_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckout_pe9: dfsdm1_ckout_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin4_pe10: dfsdm1_datin4_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin4_pe11: dfsdm1_ckin4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_datin5_pe12: dfsdm1_datin5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ dfsdm1_ckin5_pe13: dfsdm1_ckin5_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/scripts/genpinctrl/stm32-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32-pinctrl-config.yaml
@@ -56,6 +56,11 @@
   match: "^DCMI_(?:HSYNC|PIXCLK|VSYNC|D[0-7])$"
   slew-rate: very-high-speed
 
+- name: DFSDM
+  match: "^DFSDM[1-2]_(DATIN[0-7]|CKIN[0-7]|CKOUT)$"
+  slew-rate: very-high-speed
+  mode: alternate
+
 - name: ETH_COL
   match: "^ETH_COL$"
   slew-rate: very-high-speed


### PR DESCRIPTION
I'm working on a dmic driver for Zephyr which will use DFSDM, so this adds those pins to the dtsi files and updates the config.yaml.