### PR TITLE
LICENSE: Complete and clarify

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,16 +1,22 @@
 This file provides licensing information on the code provided in this repository.
 
-Two licenses are in use in this repository: Apache-2.0 and BSD-3-Clause.
+Three licenses are in use in this repository: Apache-2.0, BSD-3-Clause and ST SLA0044.
 They are applied according to the following scheme:
-- All files imported from official STM32Cube repositories are subject to their
-  original license: BSD-3-Clause
+- All files imported from STM32Cube packages are subject to their original
+  license: BSD-3-Clause. This covers following folders:
+                - stm32cube/stm32*
+                - lib/*
+- All files in dts/ folder are subject to usual Zephyr project license: Apache-2.0
+- Binary blobs explicitly fetched by the user with command `west blobs fetch stm32`
+  and stored under zephyr/blobs/stm32wba/lib are subject to ST proprietary
+  License SLA0044.
 - All other files, which are put in place for adaptation to Zephyr RTOS
   (CMakeLists.txt, ...) or available as utilities (scripts/) are subject to
   usual Zephyr project license: Apache-2.0
 - Files missing explicit license information fall under the Apache-2.0
 
 
-For these two licenses, full length texts are available hereafter:
+For these three licenses, full length texts are available hereafter:
 
 
                              BSD 3-Clause License
@@ -244,3 +250,85 @@ For these two licenses, full length texts are available hereafter:
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+
+                  SLA0044 Rev5/February 2018
+
+                 ## Software license agreement
+
+        ### __ULTIMATE LIBERTY SOFTWARE LICENSE AGREEMENT__
+
+BY INSTALLING, COPYING, DOWNLOADING, ACCESSING OR OTHERWISE USING THIS SOFTWARE
+OR ANY PART THEREOF (AND THE RELATED DOCUMENTATION) FROM STMICROELECTRONICS
+INTERNATIONAL N.V, SWISS BRANCH AND/OR ITS AFFILIATED COMPANIES
+(STMICROELECTRONICS), THE RECIPIENT, ON BEHALF OF HIMSELF OR HERSELF, OR ON
+BEHALF OF ANY ENTITY BY WHICH SUCH RECIPIENT IS EMPLOYED AND/OR ENGAGED AGREES
+TO BE BOUND BY THIS SOFTWARE LICENSE AGREEMENT.
+
+Under STMicroelectronics’ intellectual property rights, the redistribution,
+reproduction and use in source and binary forms of the software or any part
+thereof, with or without modification, are permitted provided that the following
+conditions are met:
+
+1. Redistribution of source code (modified or not) must retain any copyright
+notice, this list of conditions and the disclaimer set forth below as items 10
+and 11.
+
+2. Redistributions in binary form, except as embedded into microcontroller or
+microprocessor device manufactured by or for STMicroelectronics or a software
+update for such device, must reproduce any copyright notice provided with the
+binary code, this list of conditions, and the disclaimer set forth below as
+items 10 and 11, in documentation and/or other materials provided with the
+distribution.
+
+3. Neither the name of STMicroelectronics nor the names of other contributors to
+this software may be used to endorse or promote products derived from this
+software or part thereof without specific written permission.
+
+4. This software or any part thereof, including modifications and/or derivative
+works of this software, must be used and execute solely and exclusively on or in
+combination with a microcontroller or microprocessor device manufactured by or
+for STMicroelectronics.
+
+5. No use, reproduction or redistribution of this software partially or totally
+may be done in any manner that would subject this software to any Open Source
+Terms. “Open Source Terms” shall mean any open source license which requires as
+part of distribution of software that the source code of such software is
+distributed therewith or otherwise made available, or open source license that
+substantially complies with the Open Source definition specified at
+www.opensource.org and any other comparable open source license such as for
+example GNU General Public License (GPL), Eclipse Public License (EPL), Apache
+Software License, BSD license or MIT license.
+
+6. STMicroelectronics has no obligation to provide any maintenance, support or
+updates for the software.
+
+7. The software is and will remain the exclusive property of STMicroelectronics
+and its licensors. The recipient will not take any action that jeopardizes
+STMicroelectronics and its licensors' proprietary rights or acquire any rights
+in the software, except the limited rights specified hereunder.
+
+8. The recipient shall comply with all applicable laws and regulations affecting
+the use of the software or any part thereof including any applicable export
+control law or regulation.
+
+9. Redistribution and use of this software or any part thereof other than as
+permitted under this license is void and will automatically terminate your
+rights under this license.
+
+10. THIS SOFTWARE IS PROVIDED BY STMICROELECTRONICS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS, IMPLIED OR STATUTORY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NON-INFRINGEMENT OF THIRD PARTY INTELLECTUAL PROPERTY RIGHTS, WHICH ARE
+DISCLAIMED TO THE FULLEST EXTENT PERMITTED BY LAW. IN NO EVENT SHALL
+STMICROELECTRONICS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+11. EXCEPT AS EXPRESSLY PERMITTED HEREUNDER, NO LICENSE OR OTHER RIGHTS, WHETHER
+EXPRESS OR IMPLIED, ARE GRANTED UNDER ANY PATENT OR OTHER INTELLECTUAL PROPERTY
+RIGHTS OF STMICROELECTRONICS OR ANY THIRD PARTY.


### PR DESCRIPTION
This repo LICENSE file was missing:
- reference to SLA0044 used for STM32WBA binary blobs
- reference to Apache 2.0 Licnese used for dts files

Additionally, clarify the wording about the BSD-3-Clause license used for files extracted from STM32Cube packages and the location of the impacted files.