### PR TITLE
add ble f/w blobs for STEVAL-MKBOXPRO board

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,3 +6,8 @@
 
 add_subdirectory_ifdef(CONFIG_HAS_STM32CUBE stm32cube)
 add_subdirectory_ifdef(CONFIG_HAS_STM32LIB lib)
+
+# Add BT firmware images upgrade support for STEVAL-MKBOX board family
+if(CONFIG_BOARD_SENSORTILE_BOX OR CONFIG_BOARD_SENSORTILE_BOX_PRO)
+  add_subdirectory(ble_fw_mkbox)
+endif()

--- a/ble_fw_mkbox/CMakeLists.txt
+++ b/ble_fw_mkbox/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Copyright (c) 2024 STMicroelectronics
+#
+# Bluetooth controller-only firmware images upgrade
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set(hal_dir            ${CMAKE_CURRENT_SOURCE_DIR}/..)
+set(blob_gen_inc_file  ${ZEPHYR_BINARY_DIR}/include/generated/dtm.bin.inc)
+
+if(CONFIG_BOARD_SENSORTILE_BOX)
+  set(hal_blobs_dir      ${hal_dir}/zephyr/blobs/boards/steval-mksbox1v1)
+elseif(CONFIG_BOARD_SENSORTILE_BOX_PRO)
+  set(hal_blobs_dir      ${hal_dir}/zephyr/blobs/boards/steval-mkboxpro)
+else() # it's not a Sensortile Box board
+  set(hal_blobs_dir      "")
+endif()
+
+set(blob_hcd_file      ${hal_blobs_dir}/ble-ctrlonly-fw.bin)
+
+# generate Bluetooth include blob from .bin
+if(EXISTS ${blob_hcd_file})
+  message(INFO " generate include of ble-fw blob: ${blob_hcd_file}")
+  generate_inc_file_for_target(app ${blob_hcd_file} ${blob_gen_inc_file})
+endif()

--- a/zephyr/blobs/boards/license.md
+++ b/zephyr/blobs/boards/license.md
@@ -1,0 +1,80 @@
+SLA0044 Rev5/February 2018
+
+## Software license agreement
+
+### __ULTIMATE LIBERTY SOFTWARE LICENSE AGREEMENT__
+
+BY INSTALLING, COPYING, DOWNLOADING, ACCESSING OR OTHERWISE USING THIS SOFTWARE
+OR ANY PART THEREOF (AND THE RELATED DOCUMENTATION) FROM STMICROELECTRONICS
+INTERNATIONAL N.V, SWISS BRANCH AND/OR ITS AFFILIATED COMPANIES
+(STMICROELECTRONICS), THE RECIPIENT, ON BEHALF OF HIMSELF OR HERSELF, OR ON
+BEHALF OF ANY ENTITY BY WHICH SUCH RECIPIENT IS EMPLOYED AND/OR ENGAGED AGREES
+TO BE BOUND BY THIS SOFTWARE LICENSE AGREEMENT.
+
+Under STMicroelectronics’ intellectual property rights, the redistribution,
+reproduction and use in source and binary forms of the software or any part
+thereof, with or without modification, are permitted provided that the following
+conditions are met:
+
+1. Redistribution of source code (modified or not) must retain any copyright
+notice, this list of conditions and the disclaimer set forth below as items 10
+and 11.
+
+2. Redistributions in binary form, except as embedded into microcontroller or
+microprocessor device manufactured by or for STMicroelectronics or a software
+update for such device, must reproduce any copyright notice provided with the
+binary code, this list of conditions, and the disclaimer set forth below as
+items 10 and 11, in documentation and/or other materials provided with the
+distribution.
+
+3. Neither the name of STMicroelectronics nor the names of other contributors to
+this software may be used to endorse or promote products derived from this
+software or part thereof without specific written permission.
+
+4. This software or any part thereof, including modifications and/or derivative
+works of this software, must be used and execute solely and exclusively on or in
+combination with a microcontroller or microprocessor device manufactured by or
+for STMicroelectronics.
+
+5. No use, reproduction or redistribution of this software partially or totally
+may be done in any manner that would subject this software to any Open Source
+Terms. “Open Source Terms” shall mean any open source license which requires as
+part of distribution of software that the source code of such software is
+distributed therewith or otherwise made available, or open source license that
+substantially complies with the Open Source definition specified at
+www.opensource.org and any other comparable open source license such as for
+example GNU General Public License (GPL), Eclipse Public License (EPL), Apache
+Software License, BSD license or MIT license.
+
+6. STMicroelectronics has no obligation to provide any maintenance, support or
+updates for the software.
+
+7. The software is and will remain the exclusive property of STMicroelectronics
+and its licensors. The recipient will not take any action that jeopardizes
+STMicroelectronics and its licensors' proprietary rights or acquire any rights
+in the software, except the limited rights specified hereunder.
+
+8. The recipient shall comply with all applicable laws and regulations affecting
+the use of the software or any part thereof including any applicable export
+control law or regulation.
+
+9. Redistribution and use of this software or any part thereof other than as
+permitted under this license is void and will automatically terminate your
+rights under this license.
+
+10. THIS SOFTWARE IS PROVIDED BY STMICROELECTRONICS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS, IMPLIED OR STATUTORY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NON-INFRINGEMENT OF THIRD PARTY INTELLECTUAL PROPERTY RIGHTS, WHICH ARE
+DISCLAIMED TO THE FULLEST EXTENT PERMITTED BY LAW. IN NO EVENT SHALL
+STMICROELECTRONICS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+11. EXCEPT AS EXPRESSLY PERMITTED HEREUNDER, NO LICENSE OR OTHER RIGHTS, WHETHER
+EXPRESS OR IMPLIED, ARE GRANTED UNDER ANY PATENT OR OTHER INTELLECTUAL PROPERTY
+RIGHTS OF STMICROELECTRONICS OR ANY THIRD PARTY.

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -17,3 +17,10 @@ blobs:
     license-path: zephyr/blobs/stm32wba/lib/license.md
     url: https://github.com/STMicroelectronics/STM32CubeWBA/raw/v1.3.1/Middlewares/ST/STM32_WPAN/ble/stack/lib/stm32wba_ble_stack_llo.a
     description: "Binary Stack library for the STM32WBA Bluetooth subsystem"
+  - path: boards/steval-mkboxpro/ble-ctrlonly-fw.bin
+    sha256: f65b59363482a1122d4155ceb843b1fe7bb5612496f81feb50746f110fc27ebf
+    type: img
+    version: '1.0.0'
+    license-path: zephyr/blobs/boards/license.md
+    url: https://github.com/STMicroelectronics/stsw-mkbox-bleco/raw/v1.0.0/img/steval-mkboxpro/DTM_SPI_WITH_UPDATER_CONTROLLER.bin
+    description: "controller-only BLE f/w image for the STEVAL-MKBOXPRO board"


### PR DESCRIPTION
Configure zephyr/module.yaml to allow importation of BLE controller-only firmware required to work with zephyr bluetooth stack. Also, add in ./CMakeLists.txt the include file generation from the blob.

blobs request to TSC is [here](https://github.com/zephyrproject-rtos/zephyr/issues/74326)