### PR TITLE
lib/stm32wba/hci: Enabling extended advertising

### DIFF
--- a/lib/stm32wba/hci/README
+++ b/lib/stm32wba/hci/README
@@ -102,6 +102,9 @@ License Link:
 
 Patch List:
 
+	* Enabled extended advertising in CFG_BLE_OPTIONS:
+	  Impacted file: app_conf.h
+
 	* Disable Temperature based radio calibration:
 	  Impacted file: app_conf.h
 

--- a/lib/stm32wba/hci/app_conf.h
+++ b/lib/stm32wba/hci/app_conf.h
@@ -25,6 +25,7 @@
 /* Includes ------------------------------------------------------------------*/
 #include "hw_if.h"
 #include "utilities_conf.h"
+#include "blestack.h"
 /* #include "log_module.h" */
 
 /* USER CODE BEGIN Includes */
@@ -131,7 +132,7 @@
 #define CFG_BLE_OPTIONS             (0 | \
                                      0 | \
                                      0 | \
-                                     0 | \
+              BLE_OPTIONS_EXTENDED_ADV | \
                                      0 | \
                                      0 | \
                                      0 | \


### PR DESCRIPTION
Extended advertising option is enabled in CFG_BLE_OPTIONS