### PR TITLE
stm32h7: fix TX timestamp check

### DIFF
--- a/stm32cube/stm32f7xx/drivers/src/stm32f7xx_hal_eth.c
+++ b/stm32cube/stm32f7xx/drivers/src/stm32f7xx_hal_eth.c
@@ -1472,8 +1472,8 @@ HAL_StatusTypeDef HAL_ETH_ReleaseTxPacket(ETH_HandleTypeDef *heth)
       if ((heth->Init.TxDesc[idx].DESC0 & ETH_DMATXDESC_OWN) == 0U)
       {
 #ifdef HAL_ETH_USE_PTP
-        if ((heth->Init.TxDesc[idx].DESC3 & ETH_DMATXDESC_LS)
-            && (heth->Init.TxDesc[idx].DESC3 & ETH_DMATXDESC_TTSS))
+        if ((heth->Init.TxDesc[idx].DESC0 & ETH_DMATXDESC_LS)
+            && (heth->Init.TxDesc[idx].DESC0 & ETH_DMATXDESC_TTSS))
         {
           /* Get timestamp low */
           timestamp->TimeStampLow = heth->Init.TxDesc[idx].DESC6;


### PR DESCRIPTION
It looks like the original code was a bad copy-paste from H5 HAL. ETH_DMATXDESC_LS and ETH_DMATXDESC_TTSS are flags from the DESC0 register. This allows to effectively et the TX timestamp properly when there is one.

I wouldn't be surprised if more of such mix-ups of DESC0/1 vs., DESC2/3 would be to be found in the file but I didn't really review this.