### PR TITLE
stm32cube: soc: Set __SAUREGION_PRESENT to 0 for STM32H503

### DIFF
--- a/stm32cube/stm32h5xx/README
+++ b/stm32cube/stm32h5xx/README
@@ -67,4 +67,9 @@ Patch List:
     Impacted files:
      drivers/include/Legacy/stm32_hal_legacy.h
 
+   *Fix to set __SAUREGION_PRESENT to 0 for STM32H503 devices
+     Impacted files:
+     stm32cube/stm32h5xx/soc/stm32h503xx.h
+     ST internal bug: 177135
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32h5xx/soc/stm32h503xx.h
+++ b/stm32cube/stm32h5xx/soc/stm32h503xx.h
@@ -175,7 +175,7 @@ typedef enum
 
 /* --------  Configuration of the Cortex-M33 Processor and Core Peripherals  ------ */
 #define __CM33_REV                0x0000U   /* Core revision r0p1 */
-#define __SAUREGION_PRESENT       1U        /* SAU regions present */
+#define __SAUREGION_PRESENT       0U        /* SAU regions present */
 #define __MPU_PRESENT             1U        /* MPU present */
 #define __VTOR_PRESENT            1U        /* VTOR present */
 #define __NVIC_PRIO_BITS          4U        /* Number of Bits used for Priority Levels */


### PR DESCRIPTION
This is a mistake in CMSIS header file, since SAU is not present on STM32H503 devices