### PR TITLE
stm32 hal: BLE library is now compatible with nucleo_wba52cg

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -19,10 +19,6 @@ if(CONFIG_HAS_STM32LIB)
 
   if(CONFIG_BT_STM32WBA)
 
-    if(DEFINED CONFIG_BOARD_NUCLEO_WBA52CG)
-      message(FATAL_ERROR "BLE library is not compatible with nucleo_wba52cg")
-    endif()
-
     zephyr_compile_definitions( -DBLE )
 
     zephyr_include_directories(stm32wba/hci)


### PR DESCRIPTION
Perform a 'west blobs fetch stm32' to fetch the latest library That will make the bluetooth compatible with stm32wba52 nucleo board

in ../modules/hal/stm32/
$ west update
$ west blobs fetch stm32

resulting in 
Fetching blob stm32: ../modules/hal/stm32/zephyr/blobs/stm32wba/lib/LinkLayer_BLE_Full_lib.a
Fetching blob stm32: ../modules/hal/stm32/zephyr/blobs/stm32wba/lib/stm32wba_ble_stack_llo.a


Fixes the error
`ninja: error: '../modules/hal/stm32/zephyr/blobs/stm32wba/lib/stm32wba_ble_stack_llo.a', needed by 'zephyr/zephyr_pre0.elf', missing and no known rule to make it`

and makes the `west build  -p always -b nucleo_wba52cg samples/bluetooth/peripheral/`  successful