### PR TITLE
Add various enhancements to genpinctrl script

### DIFF
--- a/scripts/genpinctrl/genpinctrl.py
+++ b/scripts/genpinctrl/genpinctrl.py
@@ -17,7 +17,7 @@ import logging
 from pathlib import Path
 import re
 import shutil
-from subprocess import check_output
+from subprocess import check_output, STDOUT, CalledProcessError
 import xml.etree.ElementTree as ET
 
 from jinja2 import Environment, FileSystemLoader
@@ -598,8 +598,12 @@ def main(data_path, output):
                 )
 
     # write readme file
-    commit_raw = check_output(["git", "rev-parse", "HEAD"], cwd=data_path)
-    commit = commit_raw.decode("utf-8").strip()
+    try:
+        commit_raw = check_output(
+            ["git", "rev-parse", "HEAD"], cwd=data_path, stderr=STDOUT)
+        commit = commit_raw.decode("utf-8").strip()
+    except CalledProcessError:
+        commit = "<unknown commit>"
     with open(output / "README.rst", "w") as f:
         f.write(readme_template.render(commit=commit))
 


### PR DESCRIPTION
This PR adds three new features to the `genpinctrl` script to improve QoL, notably when introducing new series or regenerating pinctrl for new signals:
* graceful handling of non-Git pin data folders
  * If the pin data folder is not a git repository, script no longer crashes when generating the README file 
* support family filtering for (re)generation
  * In allowlist mode, pinctrl is generated only for specified families 
  * In forbidlist mode, pinctrl is generated for all families except those specified
  * __N.B.: when filtering is active, unlike in "default" mode, existing pinctrl files are not deleted__
* automatically detect the XML namespace from pin data files
  * Script will now attempt to detect the correct XMLNS from one file of the corpus
    * Files sourced from other places that the GitHub STMicroelectronics GitHub may use a different XML namespace
    * Before this modification, the script had to be manually edited
  * If automatic detection fails, the default `https://dummy.com` is still used
  * __N.B.: the script assumes that all files in the pin data use the same XMLNS__ (which should always be the case)