### PR TITLE
stm32h7xx_hal driver partial update to v1.11.3

### DIFF
--- a/stm32cube/stm32h7xx/drivers/src/stm32h7xx_hal_ospi.c
+++ b/stm32cube/stm32h7xx/drivers/src/stm32h7xx_hal_ospi.c
@@ -1597,7 +1597,7 @@ HAL_StatusTypeDef HAL_OSPI_Receive_DMA(OSPI_HandleTypeDef *hospi, uint8_t *pData
         }
 
         /* Enable the transmit MDMA Channel */
-        if (HAL_MDMA_Start_IT(hospi->hmdma, (uint32_t)pData, (uint32_t)&hospi->Instance->DR, hospi->XferSize, 1) == \
+        if (HAL_MDMA_Start_IT(hospi->hmdma, (uint32_t)&hospi->Instance->DR, (uint32_t)pData, hospi->XferSize, 1) == \
             HAL_OK)
         {
           /* Enable the transfer error interrupt */

--- a/stm32cube/stm32h7xx/drivers/src/stm32h7xx_ll_delayblock.c
+++ b/stm32cube/stm32h7xx/drivers/src/stm32h7xx_ll_delayblock.c
@@ -59,7 +59,7 @@
   * @{
   */
 
-#if defined(HAL_SD_MODULE_ENABLED) || defined(HAL_QSPI_MODULE_ENABLED)
+#if defined(HAL_SD_MODULE_ENABLED) || defined(HAL_QSPI_MODULE_ENABLED)|| defined(HAL_OSPI_MODULE_ENABLED)
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/


### PR DESCRIPTION
Some changes applied on the stm32h7xx_hal_driver
v1.11.3 are reported here. Until the stm32CubeH7 module is updated.

The version identified by the https://github.com/STMicroelectronics/STM32CubeH7  is v1.11.2 

So that stm32H7 serie is not updated 

However, the 
https://github.com/STMicroelectronics/stm32h7xx_hal_driver/tree/b2b4c45001f1b6b72ae449713607896fd6ca4c6b
is more a v1.11.3 

with some important changes like the one on the ospi hal driver which is put in this PR
