### PR TITLE
zephyr: module.yml: Add missing module name

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,3 +1,4 @@
+name: hal_stm32
 build:
   cmake: .
   settings:


### PR DESCRIPTION
Field `name` is missing in module.yml file.
Fix this.