### PR TITLE
ci: don't test on deprecated python versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.9', '3.10']
     steps:
       - uses: actions/checkout@v1
       - name: Set up Python


### PR DESCRIPTION
Remove Python 3.7 and 3.8 from the CI test matrix, as these versions are deprecated (3.8 goes EOL in October 2024) / EOL (since June 27th 2023 for 3.7).
This enables usage of Python 3.9+ features in scripts, such as str.removeprefix/str.removesuffix (as done in #225).
There should not be any issue caused by this since the scripts are always executed manually anyways.