### PR TITLE
stm32cube: recalibrate hsi clock after reset for H7/H7RS serie

### DIFF
--- a/stm32cube/stm32h7rsxx/drivers/src/stm32h7rsxx_ll_rcc.c
+++ b/stm32cube/stm32h7rsxx/drivers/src/stm32h7rsxx_ll_rcc.c
@@ -168,7 +168,12 @@ void LL_RCC_DeInit(void)
   /* Wait for HSI READY bit */
   while (LL_RCC_HSI_IsReady() == 0U)
   {}
+ /* Set HSIDIV Default value */
+  CLEAR_BIT(RCC->CR, RCC_CR_HSIDIV);
 
+  /* Set HSITRIM bits to the reset value */
+  LL_RCC_HSI_SetCalibTrimming(0x40U);
+  
   /* Reset CFGR register to select HSI as system clock */
   CLEAR_REG(RCC->CFGR);
 

--- a/stm32cube/stm32h7xx/drivers/src/stm32h7xx_ll_rcc.c
+++ b/stm32cube/stm32h7xx/drivers/src/stm32h7xx_ll_rcc.c
@@ -138,6 +138,12 @@ void LL_RCC_DeInit(void)
   while (LL_RCC_HSI_IsReady() == 0U)
   {}
 
+  /* Set HSIDIV Default value */
+  CLEAR_BIT(RCC->CR, RCC_CR_HSIDIV);
+
+  /* Set HSITRIM bits to the reset value */
+  LL_RCC_HSI_SetCalibTrimming(0x40U);
+
   /* Reset CFGR register */
   CLEAR_REG(RCC->CFGR);
 


### PR DESCRIPTION
This allows the HSI clock to be recalibrated after a reset to default state.

The LL_RCC_HSI_SetCalibTrimming function is already define in stm32h7xx_ll_rcc.h (line 1809) , stm32h7rsxx_ll_rcc.h (line 1615), and just need to be call where need. 

0x40U is a default hsi calibration trimming for h7 line. 

This help to fix  issue #77915  [https://github.com/zephyrproject-rtos/zephyr/issues/77915#event-14114133608](url)

