### PR TITLE
STM32f7: Fix TX timestamp check 

### DIFF
--- a/stm32cube/stm32f7xx/README
+++ b/stm32cube/stm32f7xx/README
@@ -59,4 +59,11 @@ Patch List:
     Impacted files:
      drivers/include/Legacy/stm32_hal_legacy.h
 
+   *Fix: Use the correct register DESC0
+    This fix ensures that the TX timestamp is properly set by correctly
+    checking the ETH_DMATXDESC_LS and ETH_DMATXDESC_TTSS flags in the DESC0 register.
+    Impacted files:
+     stm32cube/stm32f7xx/drivers/src/stm32f7xx_hal_eth.c
+    ST Internal reference: 185461
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32f7xx/drivers/src/stm32f7xx_hal_eth.c
+++ b/stm32cube/stm32f7xx/drivers/src/stm32f7xx_hal_eth.c
@@ -1472,8 +1472,8 @@ HAL_StatusTypeDef HAL_ETH_ReleaseTxPacket(ETH_HandleTypeDef *heth)
       if ((heth->Init.TxDesc[idx].DESC0 & ETH_DMATXDESC_OWN) == 0U)
       {
 #ifdef HAL_ETH_USE_PTP
-        if ((heth->Init.TxDesc[idx].DESC3 & ETH_DMATXDESC_LS)
-            && (heth->Init.TxDesc[idx].DESC3 & ETH_DMATXDESC_TTSS))
+        if ((heth->Init.TxDesc[idx].DESC0 & ETH_DMATXDESC_LS)
+            && (heth->Init.TxDesc[idx].DESC0 & ETH_DMATXDESC_TTSS))
         {
           /* Get timestamp low */
           timestamp->TimeStampLow = heth->Init.TxDesc[idx].DESC6;


### PR DESCRIPTION
This fix ensures that the TX timestamp is properly set by correctly
 checking the ETH_DMATXDESC_LS and ETH_DMATXDESC_TTSS flags in the DESCO register.

Fixes https://github.com/STMicroelectronics/STM32CubeF7/issues/121