### PR TITLE
ci: update upload-artifact action to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
             --cov-report html \
             -vv
       - name: store coverage report 
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: coverage-${{ matrix.python-version }}
           path: htmlcov


### PR DESCRIPTION
upload-artifact@v2 action is deprecated - update to v4 to fix CI