### PR TITLE
SAI pinctrl

### DIFF
--- a/dts/st/f4/stm32f413c(g-h)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413c(g-h)ux-pinctrl.dtsi
@@ -614,6 +614,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa15: sai1_mclk_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb3: sai1_sd_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb4: sai1_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb5: sai1_fs_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_cmd_pa6: sdio_cmd_pa6 {

--- a/dts/st/f4/stm32f413m(g-h)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413m(g-h)yx-pinctrl.dtsi
@@ -1001,6 +1001,44 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa15: sai1_mclk_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb3: sai1_sd_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb4: sai1_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb5: sai1_fs_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pc0: sai1_mclk_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pc1: sai1_sd_b_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pc2: sai1_sck_b_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pc3: sai1_fs_b_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF7)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_cmd_pa6: sdio_cmd_pa6 {

--- a/dts/st/f4/stm32f413r(g-h)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413r(g-h)tx-pinctrl.dtsi
@@ -880,6 +880,44 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa15: sai1_mclk_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb3: sai1_sd_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb4: sai1_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb5: sai1_fs_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pc0: sai1_mclk_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pc1: sai1_sd_b_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pc2: sai1_sck_b_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pc3: sai1_fs_b_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF7)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_cmd_pa6: sdio_cmd_pa6 {

--- a/dts/st/f4/stm32f413v(g-h)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413v(g-h)hx-pinctrl.dtsi
@@ -1245,6 +1245,64 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa15: sai1_mclk_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb3: sai1_sd_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb4: sai1_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb5: sai1_fs_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pc0: sai1_mclk_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pc1: sai1_sd_b_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pc2: sai1_sck_b_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pc3: sai1_fs_b_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe4: sai1_sd_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe6: sai1_fs_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF7)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_cmd_pa6: sdio_cmd_pa6 {

--- a/dts/st/f4/stm32f413v(g-h)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413v(g-h)tx-pinctrl.dtsi
@@ -1239,6 +1239,64 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa15: sai1_mclk_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb3: sai1_sd_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb4: sai1_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb5: sai1_fs_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pc0: sai1_mclk_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pc1: sai1_sd_b_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pc2: sai1_sck_b_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pc3: sai1_fs_b_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe4: sai1_sd_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe6: sai1_fs_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF7)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_cmd_pa6: sdio_cmd_pa6 {

--- a/dts/st/f4/stm32f413z(g-h)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413z(g-h)jx-pinctrl.dtsi
@@ -1447,6 +1447,80 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa15: sai1_mclk_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb3: sai1_sd_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb4: sai1_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb5: sai1_fs_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pc0: sai1_mclk_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pc1: sai1_sd_b_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pc2: sai1_sck_b_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pc3: sai1_fs_b_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe4: sai1_sd_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe6: sai1_fs_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF7)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_cmd_pa6: sdio_cmd_pa6 {

--- a/dts/st/f4/stm32f413z(g-h)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413z(g-h)tx-pinctrl.dtsi
@@ -1447,6 +1447,80 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa15: sai1_mclk_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb3: sai1_sd_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb4: sai1_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb5: sai1_fs_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pc0: sai1_mclk_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pc1: sai1_sd_b_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pc2: sai1_sck_b_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pc3: sai1_fs_b_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe4: sai1_sd_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe6: sai1_fs_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF7)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_cmd_pa6: sdio_cmd_pa6 {

--- a/dts/st/f4/stm32f423chux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423chux-pinctrl.dtsi
@@ -614,6 +614,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa15: sai1_mclk_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb3: sai1_sd_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb4: sai1_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb5: sai1_fs_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_cmd_pa6: sdio_cmd_pa6 {

--- a/dts/st/f4/stm32f423mhyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423mhyx-pinctrl.dtsi
@@ -1001,6 +1001,44 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa15: sai1_mclk_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb3: sai1_sd_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb4: sai1_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb5: sai1_fs_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pc0: sai1_mclk_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pc1: sai1_sd_b_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pc2: sai1_sck_b_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pc3: sai1_fs_b_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF7)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_cmd_pa6: sdio_cmd_pa6 {

--- a/dts/st/f4/stm32f423rhtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423rhtx-pinctrl.dtsi
@@ -880,6 +880,44 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa15: sai1_mclk_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb3: sai1_sd_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb4: sai1_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb5: sai1_fs_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pc0: sai1_mclk_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pc1: sai1_sd_b_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pc2: sai1_sck_b_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pc3: sai1_fs_b_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF7)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_cmd_pa6: sdio_cmd_pa6 {

--- a/dts/st/f4/stm32f423vhhx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423vhhx-pinctrl.dtsi
@@ -1245,6 +1245,64 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa15: sai1_mclk_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb3: sai1_sd_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb4: sai1_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb5: sai1_fs_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pc0: sai1_mclk_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pc1: sai1_sd_b_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pc2: sai1_sck_b_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pc3: sai1_fs_b_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe4: sai1_sd_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe6: sai1_fs_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF7)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_cmd_pa6: sdio_cmd_pa6 {

--- a/dts/st/f4/stm32f423vhtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423vhtx-pinctrl.dtsi
@@ -1239,6 +1239,64 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa15: sai1_mclk_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb3: sai1_sd_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb4: sai1_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb5: sai1_fs_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pc0: sai1_mclk_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pc1: sai1_sd_b_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pc2: sai1_sck_b_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pc3: sai1_fs_b_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe4: sai1_sd_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe6: sai1_fs_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF7)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_cmd_pa6: sdio_cmd_pa6 {

--- a/dts/st/f4/stm32f423zhjx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423zhjx-pinctrl.dtsi
@@ -1447,6 +1447,80 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa15: sai1_mclk_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb3: sai1_sd_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb4: sai1_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb5: sai1_fs_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pc0: sai1_mclk_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pc1: sai1_sd_b_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pc2: sai1_sck_b_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pc3: sai1_fs_b_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe4: sai1_sd_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe6: sai1_fs_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF7)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_cmd_pa6: sdio_cmd_pa6 {

--- a/dts/st/f4/stm32f423zhtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423zhtx-pinctrl.dtsi
@@ -1447,6 +1447,80 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa15: sai1_mclk_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb3: sai1_sd_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb4: sai1_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb5: sai1_fs_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pc0: sai1_mclk_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pc1: sai1_sd_b_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pc2: sai1_sck_b_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pc3: sai1_fs_b_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe4: sai1_sd_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe6: sai1_fs_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF7)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_cmd_pa6: sdio_cmd_pa6 {

--- a/dts/st/f4/stm32f427a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427a(g-i)hx-pinctrl.dtsi
@@ -1843,6 +1843,32 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f427i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427i(g-i)hx-pinctrl.dtsi
@@ -1938,6 +1938,48 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f427i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427i(g-i)tx-pinctrl.dtsi
@@ -1938,6 +1938,48 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f427v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427v(g-i)tx-pinctrl.dtsi
@@ -1209,6 +1209,32 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f427z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427z(g-i)tx-pinctrl.dtsi
@@ -1565,6 +1565,48 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f429a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429a(g-i)hx-pinctrl.dtsi
@@ -2057,6 +2057,32 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f429b(e-g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429b(e-g-i)tx-pinctrl.dtsi
@@ -2376,6 +2376,48 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f429i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429i(e-g)tx-pinctrl.dtsi
@@ -2152,6 +2152,48 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f429i(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429i(e-g-i)hx-pinctrl.dtsi
@@ -2152,6 +2152,48 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f429iitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429iitx-pinctrl.dtsi
@@ -2152,6 +2152,48 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f429n(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429n(e-g)hx-pinctrl.dtsi
@@ -2376,6 +2376,48 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f429nihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429nihx-pinctrl.dtsi
@@ -2376,6 +2376,48 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f429v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429v(e-g)tx-pinctrl.dtsi
@@ -1285,6 +1285,32 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f429vitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429vitx-pinctrl.dtsi
@@ -1285,6 +1285,32 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f429z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429z(e-g)tx-pinctrl.dtsi
@@ -1703,6 +1703,48 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f429zgyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429zgyx-pinctrl.dtsi
@@ -1703,6 +1703,48 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f429zitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429zitx-pinctrl.dtsi
@@ -1703,6 +1703,48 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f429ziyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429ziyx-pinctrl.dtsi
@@ -1703,6 +1703,48 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f437aihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437aihx-pinctrl.dtsi
@@ -1843,6 +1843,32 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f437i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437i(g-i)hx-pinctrl.dtsi
@@ -1938,6 +1938,48 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f437i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437i(g-i)tx-pinctrl.dtsi
@@ -1938,6 +1938,48 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f437v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437v(g-i)tx-pinctrl.dtsi
@@ -1209,6 +1209,32 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f437z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437z(g-i)tx-pinctrl.dtsi
@@ -1565,6 +1565,48 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f439aihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439aihx-pinctrl.dtsi
@@ -2057,6 +2057,32 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f439b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439b(g-i)tx-pinctrl.dtsi
@@ -2376,6 +2376,48 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f439i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439i(g-i)hx-pinctrl.dtsi
@@ -2152,6 +2152,48 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f439i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439i(g-i)tx-pinctrl.dtsi
@@ -2152,6 +2152,48 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f439n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439n(g-i)hx-pinctrl.dtsi
@@ -2376,6 +2376,48 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f439v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439v(g-i)tx-pinctrl.dtsi
@@ -1285,6 +1285,32 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f439z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439z(g-i)tx-pinctrl.dtsi
@@ -1703,6 +1703,48 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f439z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439z(g-i)yx-pinctrl.dtsi
@@ -1703,6 +1703,48 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f446m(c-e)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446m(c-e)yx-pinctrl.dtsi
@@ -864,6 +864,76 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_fs_a_pa3: sai1_fs_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa9: sai1_sd_b_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb9: sai1_fs_b_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb12: sai1_sck_b_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pc0: sai1_mclk_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d1_pb0: sdio_d1_pb0 {

--- a/dts/st/f4/stm32f446r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446r(c-e)tx-pinctrl.dtsi
@@ -774,6 +774,40 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_fs_a_pa3: sai1_fs_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa9: sai1_sd_b_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb9: sai1_fs_b_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb12: sai1_sck_b_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pc0: sai1_mclk_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d1_pb0: sdio_d1_pb0 {

--- a/dts/st/f4/stm32f446v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446v(c-e)tx-pinctrl.dtsi
@@ -1241,6 +1241,112 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_fs_a_pa3: sai1_fs_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa9: sai1_sd_b_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb9: sai1_fs_b_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb12: sai1_sck_b_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pc0: sai1_mclk_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd14: sai2_sck_a_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d1_pb0: sdio_d1_pb0 {

--- a/dts/st/f4/stm32f446z(c-e)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)hx-pinctrl.dtsi
@@ -1622,6 +1622,144 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_fs_a_pa3: sai1_fs_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa9: sai1_sd_b_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb9: sai1_fs_b_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb12: sai1_sck_b_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pc0: sai1_mclk_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb11: sai2_sd_a_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd14: sai2_sck_a_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d1_pb0: sdio_d1_pb0 {

--- a/dts/st/f4/stm32f446z(c-e)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)jx-pinctrl.dtsi
@@ -1622,6 +1622,144 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_fs_a_pa3: sai1_fs_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa9: sai1_sd_b_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb9: sai1_fs_b_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb12: sai1_sck_b_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pc0: sai1_mclk_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb11: sai2_sd_a_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd14: sai2_sck_a_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d1_pb0: sdio_d1_pb0 {

--- a/dts/st/f4/stm32f446z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)tx-pinctrl.dtsi
@@ -1622,6 +1622,144 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_fs_a_pa3: sai1_fs_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa9: sai1_sd_b_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb9: sai1_fs_b_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb12: sai1_sck_b_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pc0: sai1_mclk_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb11: sai2_sd_a_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd14: sai2_sck_a_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d1_pb0: sdio_d1_pb0 {

--- a/dts/st/f4/stm32f469a(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469a(e-g-i)hx-pinctrl.dtsi
@@ -1989,6 +1989,40 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f469a(e-g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469a(e-g-i)yx-pinctrl.dtsi
@@ -1989,6 +1989,40 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f469b(e-g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469b(e-g-i)tx-pinctrl.dtsi
@@ -2537,6 +2537,56 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f469i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469i(e-g)tx-pinctrl.dtsi
@@ -2198,6 +2198,56 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f469i(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469i(e-g-i)hx-pinctrl.dtsi
@@ -2198,6 +2198,56 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f469iitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469iitx-pinctrl.dtsi
@@ -2198,6 +2198,56 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f469n(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469n(e-g)hx-pinctrl.dtsi
@@ -2537,6 +2537,56 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f469nihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469nihx-pinctrl.dtsi
@@ -2537,6 +2537,56 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f469v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469v(e-g)tx-pinctrl.dtsi
@@ -1128,6 +1128,20 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f469vitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469vitx-pinctrl.dtsi
@@ -1128,6 +1128,20 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f469z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469z(e-g)tx-pinctrl.dtsi
@@ -1623,6 +1623,40 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f469zitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469zitx-pinctrl.dtsi
@@ -1623,6 +1623,40 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f479a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479a(g-i)hx-pinctrl.dtsi
@@ -1989,6 +1989,40 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f479a(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479a(g-i)yx-pinctrl.dtsi
@@ -1989,6 +1989,40 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f479b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479b(g-i)tx-pinctrl.dtsi
@@ -2537,6 +2537,56 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f479i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479i(g-i)hx-pinctrl.dtsi
@@ -2198,6 +2198,56 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f479i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479i(g-i)tx-pinctrl.dtsi
@@ -2198,6 +2198,56 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f479n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479n(g-i)hx-pinctrl.dtsi
@@ -2537,6 +2537,56 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f479v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479v(g-i)tx-pinctrl.dtsi
@@ -1128,6 +1128,20 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f479z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479z(g-i)tx-pinctrl.dtsi
@@ -1623,6 +1623,40 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
 			/* SDIO */
 
 			/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f7/stm32f722i(c-e)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722i(c-e)kx-pinctrl.dtsi
@@ -1769,6 +1769,148 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f722i(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722i(c-e)tx-pinctrl.dtsi
@@ -1769,6 +1769,148 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f722r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722r(c-e)tx-pinctrl.dtsi
@@ -651,6 +651,36 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f722v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722v(c-e)tx-pinctrl.dtsi
@@ -1087,6 +1087,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f722z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722z(c-e)tx-pinctrl.dtsi
@@ -1456,6 +1456,124 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f723i(c-e)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723i(c-e)kx-pinctrl.dtsi
@@ -1751,6 +1751,148 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f723i(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723i(c-e)tx-pinctrl.dtsi
@@ -1751,6 +1751,148 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f723v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723v(c-e)tx-pinctrl.dtsi
@@ -1053,6 +1053,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f723v(c-e)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723v(c-e)yx-pinctrl.dtsi
@@ -1053,6 +1053,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f723z(c-e)ix-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723z(c-e)ix-pinctrl.dtsi
@@ -1438,6 +1438,124 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f723z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723z(c-e)tx-pinctrl.dtsi
@@ -1438,6 +1438,124 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f730i8kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730i8kx-pinctrl.dtsi
@@ -1751,6 +1751,148 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f730r8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730r8tx-pinctrl.dtsi
@@ -651,6 +651,36 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f730v8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730v8tx-pinctrl.dtsi
@@ -1087,6 +1087,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f730z8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730z8tx-pinctrl.dtsi
@@ -1438,6 +1438,124 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f732iekx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732iekx-pinctrl.dtsi
@@ -1769,6 +1769,148 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f732ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732ietx-pinctrl.dtsi
@@ -1769,6 +1769,148 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f732retx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732retx-pinctrl.dtsi
@@ -651,6 +651,36 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f732vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732vetx-pinctrl.dtsi
@@ -1087,6 +1087,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f732zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732zetx-pinctrl.dtsi
@@ -1456,6 +1456,124 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f733iekx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733iekx-pinctrl.dtsi
@@ -1751,6 +1751,148 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f733ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733ietx-pinctrl.dtsi
@@ -1751,6 +1751,148 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f733vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733vetx-pinctrl.dtsi
@@ -1053,6 +1053,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f733veyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733veyx-pinctrl.dtsi
@@ -1053,6 +1053,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f733zeix-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733zeix-pinctrl.dtsi
@@ -1438,6 +1438,124 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f733zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733zetx-pinctrl.dtsi
@@ -1438,6 +1438,124 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f745i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745i(e-g)kx-pinctrl.dtsi
@@ -2179,6 +2179,148 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f745i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745i(e-g)tx-pinctrl.dtsi
@@ -2179,6 +2179,148 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f745v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745v(e-g)hx-pinctrl.dtsi
@@ -1364,6 +1364,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f745v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745v(e-g)tx-pinctrl.dtsi
@@ -1364,6 +1364,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f745z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745z(e-g)tx-pinctrl.dtsi
@@ -1779,6 +1779,124 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
@@ -2641,6 +2641,148 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
@@ -2417,6 +2417,148 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f746ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746ietx-pinctrl.dtsi
@@ -2417,6 +2417,148 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f746igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746igtx-pinctrl.dtsi
@@ -2417,6 +2417,148 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f746nehx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nehx-pinctrl.dtsi
@@ -2641,6 +2641,148 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f746nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nghx-pinctrl.dtsi
@@ -2641,6 +2641,148 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f746v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746v(e-g)hx-pinctrl.dtsi
@@ -1486,6 +1486,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f746vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746vetx-pinctrl.dtsi
@@ -1486,6 +1486,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f746vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746vgtx-pinctrl.dtsi
@@ -1486,6 +1486,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
@@ -1941,6 +1941,124 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f746zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zetx-pinctrl.dtsi
@@ -1941,6 +1941,124 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
@@ -1941,6 +1941,124 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
@@ -2641,6 +2641,148 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f750v8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750v8tx-pinctrl.dtsi
@@ -1486,6 +1486,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
@@ -1941,6 +1941,124 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
@@ -2641,6 +2641,148 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f756igkx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igkx-pinctrl.dtsi
@@ -2417,6 +2417,148 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f756igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igtx-pinctrl.dtsi
@@ -2417,6 +2417,148 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f756nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756nghx-pinctrl.dtsi
@@ -2641,6 +2641,148 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f756vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756vghx-pinctrl.dtsi
@@ -1486,6 +1486,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f756vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756vgtx-pinctrl.dtsi
@@ -1486,6 +1486,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
@@ -1941,6 +1941,124 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
@@ -1941,6 +1941,124 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
@@ -2662,6 +2662,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
@@ -2550,6 +2550,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
@@ -2550,6 +2550,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
@@ -2662,6 +2662,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f765v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765v(g-i)hx-pinctrl.dtsi
@@ -1700,6 +1700,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f765v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765v(g-i)tx-pinctrl.dtsi
@@ -1700,6 +1700,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
@@ -2145,6 +2145,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
@@ -3084,6 +3084,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
@@ -2844,6 +2844,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
@@ -2844,6 +2844,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
@@ -3084,6 +3084,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f767vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vghx-pinctrl.dtsi
@@ -1862,6 +1862,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
@@ -1862,6 +1862,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f767vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vihx-pinctrl.dtsi
@@ -1862,6 +1862,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f767vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vitx-pinctrl.dtsi
@@ -1862,6 +1862,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
@@ -2351,6 +2351,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f767zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zitx-pinctrl.dtsi
@@ -2351,6 +2351,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
@@ -2434,6 +2434,136 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
@@ -2434,6 +2434,136 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
@@ -3012,6 +3012,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f769igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769igtx-pinctrl.dtsi
@@ -2651,6 +2651,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f769iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769iitx-pinctrl.dtsi
@@ -2651,6 +2651,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f769nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nghx-pinctrl.dtsi
@@ -3012,6 +3012,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f769nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nihx-pinctrl.dtsi
@@ -3012,6 +3012,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f777bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777bitx-pinctrl.dtsi
@@ -3084,6 +3084,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f777iikx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iikx-pinctrl.dtsi
@@ -2844,6 +2844,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f777iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iitx-pinctrl.dtsi
@@ -2844,6 +2844,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f777nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777nihx-pinctrl.dtsi
@@ -3084,6 +3084,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f777vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vihx-pinctrl.dtsi
@@ -1862,6 +1862,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f777vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vitx-pinctrl.dtsi
@@ -1862,6 +1862,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f777zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777zitx-pinctrl.dtsi
@@ -2351,6 +2351,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
@@ -2434,6 +2434,136 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
@@ -2434,6 +2434,136 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f779bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779bitx-pinctrl.dtsi
@@ -3012,6 +3012,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f779iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779iitx-pinctrl.dtsi
@@ -2651,6 +2651,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f779nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779nihx-pinctrl.dtsi
@@ -3012,6 +3012,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/g4/stm32g431c(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431c(6-8-b)tx-pinctrl.dtsi
@@ -468,6 +468,84 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g431c(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431c(6-8-b)ux-pinctrl.dtsi
@@ -510,6 +510,84 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g431cbtxz-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431cbtxz-pinctrl.dtsi
@@ -468,6 +468,84 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g431cbyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431cbyx-pinctrl.dtsi
@@ -501,6 +501,84 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g431k(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431k(6-8-b)tx-pinctrl.dtsi
@@ -359,6 +359,72 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g431k(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431k(6-8-b)ux-pinctrl.dtsi
@@ -359,6 +359,72 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g431m(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431m(6-8-b)tx-pinctrl.dtsi
@@ -671,6 +671,116 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g431r(6-8-b)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431r(6-8-b)ix-pinctrl.dtsi
@@ -607,6 +607,100 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g431r(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431r(6-8-b)tx-pinctrl.dtsi
@@ -607,6 +607,100 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g431rbtxz-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431rbtxz-pinctrl.dtsi
@@ -607,6 +607,100 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g431v(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431v(6-8-b)tx-pinctrl.dtsi
@@ -756,6 +756,168 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g441cbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441cbtx-pinctrl.dtsi
@@ -468,6 +468,84 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g441cbux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441cbux-pinctrl.dtsi
@@ -510,6 +510,84 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g441cbyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441cbyx-pinctrl.dtsi
@@ -501,6 +501,84 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g441kbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441kbtx-pinctrl.dtsi
@@ -359,6 +359,72 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g441kbux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441kbux-pinctrl.dtsi
@@ -359,6 +359,72 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g441mbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441mbtx-pinctrl.dtsi
@@ -671,6 +671,116 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g441rbix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441rbix-pinctrl.dtsi
@@ -607,6 +607,100 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g441rbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441rbtx-pinctrl.dtsi
@@ -607,6 +607,100 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g441vbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441vbtx-pinctrl.dtsi
@@ -756,6 +756,168 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g471c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471c(c-e)tx-pinctrl.dtsi
@@ -560,6 +560,84 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g471c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471c(c-e)ux-pinctrl.dtsi
@@ -613,6 +613,84 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g471m(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471m(c-e)tx-pinctrl.dtsi
@@ -857,6 +857,116 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g471meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471meyx-pinctrl.dtsi
@@ -870,6 +870,116 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g471q(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471q(c-e)tx-pinctrl.dtsi
@@ -1161,6 +1161,188 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g471r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471r(c-e)tx-pinctrl.dtsi
@@ -731,6 +731,100 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g471v(c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471v(c-e)hx-pinctrl.dtsi
@@ -998,6 +998,168 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g471v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471v(c-e)ix-pinctrl.dtsi
@@ -998,6 +998,168 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g471v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471v(c-e)tx-pinctrl.dtsi
@@ -998,6 +998,168 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g473c(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473c(b-c-e)tx-pinctrl.dtsi
@@ -600,6 +600,84 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g473c(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473c(b-c-e)ux-pinctrl.dtsi
@@ -653,6 +653,84 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g473m(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473m(b-c-e)tx-pinctrl.dtsi
@@ -961,6 +961,116 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g473meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473meyx-pinctrl.dtsi
@@ -982,6 +982,116 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g473p(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473p(b-c-e)ix-pinctrl.dtsi
@@ -1568,6 +1568,180 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g473q(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473q(b-c-e)tx-pinctrl.dtsi
@@ -1641,6 +1641,188 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g473qetxz-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473qetxz-pinctrl.dtsi
@@ -1641,6 +1641,188 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g473r(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473r(b-c-e)tx-pinctrl.dtsi
@@ -771,6 +771,100 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g473retxz-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473retxz-pinctrl.dtsi
@@ -779,6 +779,100 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g473v(b-c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473v(b-c-e)hx-pinctrl.dtsi
@@ -1352,6 +1352,168 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g473v(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473v(b-c-e)tx-pinctrl.dtsi
@@ -1352,6 +1352,168 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g474c(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474c(b-c-e)tx-pinctrl.dtsi
@@ -682,6 +682,84 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g474c(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474c(b-c-e)ux-pinctrl.dtsi
@@ -747,6 +747,84 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g474m(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474m(b-c-e)tx-pinctrl.dtsi
@@ -1075,6 +1075,116 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g474meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474meyx-pinctrl.dtsi
@@ -1096,6 +1096,116 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g474p(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474p(b-c-e)ix-pinctrl.dtsi
@@ -1682,6 +1682,180 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g474q(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474q(b-c-e)tx-pinctrl.dtsi
@@ -1755,6 +1755,188 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g474r(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474r(b-c-e)tx-pinctrl.dtsi
@@ -885,6 +885,100 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g474v(b-c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)hx-pinctrl.dtsi
@@ -1466,6 +1466,168 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g474v(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)tx-pinctrl.dtsi
@@ -1466,6 +1466,168 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g483cetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483cetx-pinctrl.dtsi
@@ -600,6 +600,84 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g483ceux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483ceux-pinctrl.dtsi
@@ -653,6 +653,84 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g483metx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483metx-pinctrl.dtsi
@@ -961,6 +961,116 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g483meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483meyx-pinctrl.dtsi
@@ -982,6 +982,116 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g483peix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483peix-pinctrl.dtsi
@@ -1568,6 +1568,180 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g483qetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483qetx-pinctrl.dtsi
@@ -1641,6 +1641,188 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g483retx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483retx-pinctrl.dtsi
@@ -771,6 +771,100 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g483vehx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483vehx-pinctrl.dtsi
@@ -1352,6 +1352,168 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g483vetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483vetx-pinctrl.dtsi
@@ -1352,6 +1352,168 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g484cetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484cetx-pinctrl.dtsi
@@ -682,6 +682,84 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g484ceux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484ceux-pinctrl.dtsi
@@ -747,6 +747,84 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g484metx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484metx-pinctrl.dtsi
@@ -1075,6 +1075,116 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g484meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484meyx-pinctrl.dtsi
@@ -1096,6 +1096,116 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g484peix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484peix-pinctrl.dtsi
@@ -1682,6 +1682,180 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g484qetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484qetx-pinctrl.dtsi
@@ -1755,6 +1755,188 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g484retx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484retx-pinctrl.dtsi
@@ -885,6 +885,100 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g484vehx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484vehx-pinctrl.dtsi
@@ -1466,6 +1466,168 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g484vetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484vetx-pinctrl.dtsi
@@ -1466,6 +1466,168 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g491c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491c(c-e)tx-pinctrl.dtsi
@@ -543,6 +543,84 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g491c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491c(c-e)ux-pinctrl.dtsi
@@ -590,6 +590,84 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g491k(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491k(c-e)ux-pinctrl.dtsi
@@ -398,6 +398,72 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g491m(c-e)sx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491m(c-e)sx-pinctrl.dtsi
@@ -828,6 +828,116 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g491m(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491m(c-e)tx-pinctrl.dtsi
@@ -828,6 +828,116 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g491r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491r(c-e)ix-pinctrl.dtsi
@@ -702,6 +702,100 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g491r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491r(c-e)tx-pinctrl.dtsi
@@ -702,6 +702,100 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g491retxz-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491retxz-pinctrl.dtsi
@@ -702,6 +702,100 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g491reyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491reyx-pinctrl.dtsi
@@ -702,6 +702,100 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g491v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491v(c-e)tx-pinctrl.dtsi
@@ -964,6 +964,168 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g4a1cetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1cetx-pinctrl.dtsi
@@ -543,6 +543,84 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g4a1ceux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1ceux-pinctrl.dtsi
@@ -590,6 +590,84 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g4a1keux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1keux-pinctrl.dtsi
@@ -398,6 +398,72 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g4a1mesx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1mesx-pinctrl.dtsi
@@ -828,6 +828,116 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g4a1metx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1metx-pinctrl.dtsi
@@ -828,6 +828,116 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g4a1reix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1reix-pinctrl.dtsi
@@ -702,6 +702,100 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g4a1retx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1retx-pinctrl.dtsi
@@ -702,6 +702,100 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g4a1reyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1reyx-pinctrl.dtsi
@@ -702,6 +702,100 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g4a1vetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1vetx-pinctrl.dtsi
@@ -964,6 +964,168 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/h5/stm32h562agix-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562agix-pinctrl.dtsi
@@ -2213,6 +2213,224 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg7: sai1_ck2_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h562aiix-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562aiix-pinctrl.dtsi
@@ -2213,6 +2213,224 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg7: sai1_ck2_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h562igkx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562igkx-pinctrl.dtsi
@@ -2252,6 +2252,228 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg7: sai1_ck2_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h562igtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562igtx-pinctrl.dtsi
@@ -2252,6 +2252,228 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg7: sai1_ck2_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h562iikx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562iikx-pinctrl.dtsi
@@ -2252,6 +2252,228 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg7: sai1_ck2_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h562iitx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562iitx-pinctrl.dtsi
@@ -2252,6 +2252,228 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg7: sai1_ck2_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h562rgtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562rgtx-pinctrl.dtsi
@@ -884,6 +884,76 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h562rgvx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562rgvx-pinctrl.dtsi
@@ -971,6 +971,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h562ritx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562ritx-pinctrl.dtsi
@@ -884,6 +884,76 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h562rivx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562rivx-pinctrl.dtsi
@@ -971,6 +971,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h562vgtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562vgtx-pinctrl.dtsi
@@ -1483,6 +1483,164 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h562vitx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562vitx-pinctrl.dtsi
@@ -1483,6 +1483,164 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h562zgtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562zgtx-pinctrl.dtsi
@@ -1932,6 +1932,204 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg7: sai1_ck2_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h562zitx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562zitx-pinctrl.dtsi
@@ -1932,6 +1932,204 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg7: sai1_ck2_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h563agix-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563agix-pinctrl.dtsi
@@ -2437,6 +2437,224 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg7: sai1_ck2_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h563aiix-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563aiix-pinctrl.dtsi
@@ -2437,6 +2437,224 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg7: sai1_ck2_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h563aiixq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563aiixq-pinctrl.dtsi
@@ -2402,6 +2402,228 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg7: sai1_ck2_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h563igkx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563igkx-pinctrl.dtsi
@@ -2481,6 +2481,228 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg7: sai1_ck2_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h563igtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563igtx-pinctrl.dtsi
@@ -2481,6 +2481,228 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg7: sai1_ck2_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h563iikx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563iikx-pinctrl.dtsi
@@ -2481,6 +2481,228 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg7: sai1_ck2_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h563iikxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563iikxq-pinctrl.dtsi
@@ -2473,6 +2473,228 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg7: sai1_ck2_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h563iitx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563iitx-pinctrl.dtsi
@@ -2481,6 +2481,228 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg7: sai1_ck2_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h563iitxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563iitxq-pinctrl.dtsi
@@ -2431,6 +2431,224 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg7: sai1_ck2_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h563miyxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563miyxq-pinctrl.dtsi
@@ -1273,6 +1273,76 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h563rgtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563rgtx-pinctrl.dtsi
@@ -1049,6 +1049,76 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h563rgvx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563rgvx-pinctrl.dtsi
@@ -1141,6 +1141,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h563ritx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563ritx-pinctrl.dtsi
@@ -1049,6 +1049,76 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h563rivx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563rivx-pinctrl.dtsi
@@ -1141,6 +1141,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h563vgtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563vgtx-pinctrl.dtsi
@@ -1657,6 +1657,164 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h563vitx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563vitx-pinctrl.dtsi
@@ -1657,6 +1657,164 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h563vitxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563vitxq-pinctrl.dtsi
@@ -1446,6 +1446,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h563zgtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563zgtx-pinctrl.dtsi
@@ -2131,6 +2131,204 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg7: sai1_ck2_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h563zitx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563zitx-pinctrl.dtsi
@@ -2131,6 +2131,204 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg7: sai1_ck2_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h563zitxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563zitxq-pinctrl.dtsi
@@ -1900,6 +1900,192 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg7: sai1_ck2_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h573aiix-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573aiix-pinctrl.dtsi
@@ -2437,6 +2437,224 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg7: sai1_ck2_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h573aiixq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573aiixq-pinctrl.dtsi
@@ -2402,6 +2402,228 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg7: sai1_ck2_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h573iikx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573iikx-pinctrl.dtsi
@@ -2481,6 +2481,228 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg7: sai1_ck2_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h573iikxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573iikxq-pinctrl.dtsi
@@ -2473,6 +2473,228 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg7: sai1_ck2_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h573iitx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573iitx-pinctrl.dtsi
@@ -2481,6 +2481,228 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg7: sai1_ck2_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h573iitxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573iitxq-pinctrl.dtsi
@@ -2431,6 +2431,224 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg7: sai1_ck2_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h573miyxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573miyxq-pinctrl.dtsi
@@ -1273,6 +1273,76 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h573ritx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573ritx-pinctrl.dtsi
@@ -1049,6 +1049,76 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h573rivx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573rivx-pinctrl.dtsi
@@ -1141,6 +1141,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h573vitx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573vitx-pinctrl.dtsi
@@ -1657,6 +1657,164 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h573vitxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573vitxq-pinctrl.dtsi
@@ -1446,6 +1446,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h573zitx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573zitx-pinctrl.dtsi
@@ -2131,6 +2131,204 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc4: sai1_ck1_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pc5: sai1_fs_a_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg7: sai1_ck2_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h5/stm32h573zitxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573zitxq-pinctrl.dtsi
@@ -1900,6 +1900,192 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc0: sai1_mclk_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc3: sai1_d3_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc6: sai1_sck_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd11: sai1_ck1_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd12: sai1_d1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg7: sai1_ck2_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pc1: sai2_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d0_pa10: sdmmc1_d0_pa10 {

--- a/dts/st/h7/stm32h723vehx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vehx-pinctrl.dtsi
@@ -2122,6 +2122,192 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe0: sai4_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe6: sai4_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe11: sai4_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pe12: sai4_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pe13: sai4_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe14: sai4_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h723vetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vetx-pinctrl.dtsi
@@ -2122,6 +2122,192 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe0: sai4_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe6: sai4_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe11: sai4_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pe12: sai4_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pe13: sai4_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe14: sai4_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h723vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vghx-pinctrl.dtsi
@@ -2122,6 +2122,192 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe0: sai4_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe6: sai4_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe11: sai4_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pe12: sai4_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pe13: sai4_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe14: sai4_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h723vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vgtx-pinctrl.dtsi
@@ -2122,6 +2122,192 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe0: sai4_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe6: sai4_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe11: sai4_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pe12: sai4_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pe13: sai4_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe14: sai4_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h723zeix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zeix-pinctrl.dtsi
@@ -2806,6 +2806,248 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe0: sai4_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe6: sai4_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe11: sai4_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pe12: sai4_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pe13: sai4_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe14: sai4_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf11: sai4_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pg9: sai4_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pg10: sai4_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h723zetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zetx-pinctrl.dtsi
@@ -2778,6 +2778,248 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe0: sai4_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe6: sai4_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe11: sai4_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pe12: sai4_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pe13: sai4_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe14: sai4_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf11: sai4_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pg9: sai4_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pg10: sai4_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h723zgix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zgix-pinctrl.dtsi
@@ -2806,6 +2806,248 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe0: sai4_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe6: sai4_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe11: sai4_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pe12: sai4_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pe13: sai4_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe14: sai4_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf11: sai4_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pg9: sai4_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pg10: sai4_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h723zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zgtx-pinctrl.dtsi
@@ -2778,6 +2778,248 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe0: sai4_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe6: sai4_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe11: sai4_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pe12: sai4_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pe13: sai4_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe14: sai4_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf11: sai4_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pg9: sai4_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pg10: sai4_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725aeix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725aeix-pinctrl.dtsi
@@ -3129,6 +3129,264 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0_c: sai4_sd_b_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1_c: sai4_mclk_b_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe0: sai4_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe6: sai4_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe11: sai4_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pe12: sai4_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pe13: sai4_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe14: sai4_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf11: sai4_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pg9: sai4_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pg10: sai4_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_ph2: sai4_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_ph3: sai4_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725agix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725agix-pinctrl.dtsi
@@ -3129,6 +3129,264 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0_c: sai4_sd_b_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1_c: sai4_mclk_b_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe0: sai4_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe6: sai4_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe11: sai4_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pe12: sai4_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pe13: sai4_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe14: sai4_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf11: sai4_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pg9: sai4_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pg10: sai4_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_ph2: sai4_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_ph3: sai4_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725iekx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725iekx-pinctrl.dtsi
@@ -3279,6 +3279,264 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0_c: sai4_sd_b_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1_c: sai4_mclk_b_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe0: sai4_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe6: sai4_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe11: sai4_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pe12: sai4_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pe13: sai4_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe14: sai4_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf11: sai4_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pg9: sai4_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pg10: sai4_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_ph2: sai4_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_ph3: sai4_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725ietx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725ietx-pinctrl.dtsi
@@ -2834,6 +2834,248 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe0: sai4_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe6: sai4_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe11: sai4_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pe12: sai4_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pe13: sai4_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe14: sai4_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf11: sai4_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pg9: sai4_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pg10: sai4_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725igkx-pinctrl.dtsi
@@ -3279,6 +3279,264 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0_c: sai4_sd_b_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1_c: sai4_mclk_b_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe0: sai4_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe6: sai4_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe11: sai4_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pe12: sai4_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pe13: sai4_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe14: sai4_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf11: sai4_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pg9: sai4_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pg10: sai4_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_ph2: sai4_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_ph3: sai4_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725igtx-pinctrl.dtsi
@@ -2834,6 +2834,248 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe0: sai4_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe6: sai4_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe11: sai4_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pe12: sai4_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pe13: sai4_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe14: sai4_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf11: sai4_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pg9: sai4_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pg10: sai4_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725revx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725revx-pinctrl.dtsi
@@ -1139,6 +1139,48 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725rgvx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725rgvx-pinctrl.dtsi
@@ -1139,6 +1139,48 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725vehx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vehx-pinctrl.dtsi
@@ -2032,6 +2032,176 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe0: sai4_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe6: sai4_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725vetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vetx-pinctrl.dtsi
@@ -1871,6 +1871,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vghx-pinctrl.dtsi
@@ -2032,6 +2032,176 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe0: sai4_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe6: sai4_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vgtx-pinctrl.dtsi
@@ -1871,6 +1871,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725vgyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vgyx-pinctrl.dtsi
@@ -1785,6 +1785,116 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe0: sai4_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725zetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725zetx-pinctrl.dtsi
@@ -2506,6 +2506,248 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe0: sai4_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe6: sai4_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe11: sai4_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pe12: sai4_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pe13: sai4_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe14: sai4_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf11: sai4_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pg9: sai4_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pg10: sai4_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725zgtx-pinctrl.dtsi
@@ -2506,6 +2506,248 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe0: sai4_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe6: sai4_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe11: sai4_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pe12: sai4_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pe13: sai4_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe14: sai4_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf11: sai4_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pg9: sai4_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pg10: sai4_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h730abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730abixq-pinctrl.dtsi
@@ -3129,6 +3129,264 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0_c: sai4_sd_b_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1_c: sai4_mclk_b_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe0: sai4_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe6: sai4_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe11: sai4_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pe12: sai4_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pe13: sai4_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe14: sai4_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf11: sai4_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pg9: sai4_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pg10: sai4_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_ph2: sai4_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_ph3: sai4_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h730ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730ibkxq-pinctrl.dtsi
@@ -3279,6 +3279,264 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0_c: sai4_sd_b_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1_c: sai4_mclk_b_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe0: sai4_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe6: sai4_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe11: sai4_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pe12: sai4_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pe13: sai4_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe14: sai4_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf11: sai4_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pg9: sai4_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pg10: sai4_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_ph2: sai4_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_ph3: sai4_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h730ibtxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730ibtxq-pinctrl.dtsi
@@ -2834,6 +2834,248 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe0: sai4_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe6: sai4_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe11: sai4_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pe12: sai4_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pe13: sai4_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe14: sai4_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf11: sai4_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pg9: sai4_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pg10: sai4_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h730vbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730vbhx-pinctrl.dtsi
@@ -2122,6 +2122,192 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe0: sai4_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe6: sai4_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe11: sai4_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pe12: sai4_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pe13: sai4_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe14: sai4_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h730vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730vbtx-pinctrl.dtsi
@@ -2122,6 +2122,192 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe0: sai4_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe6: sai4_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe11: sai4_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pe12: sai4_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pe13: sai4_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe14: sai4_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h730zbix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730zbix-pinctrl.dtsi
@@ -2806,6 +2806,248 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe0: sai4_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe6: sai4_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe11: sai4_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pe12: sai4_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pe13: sai4_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe14: sai4_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf11: sai4_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pg9: sai4_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pg10: sai4_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h730zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730zbtx-pinctrl.dtsi
@@ -2778,6 +2778,248 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe0: sai4_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe6: sai4_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe11: sai4_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pe12: sai4_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pe13: sai4_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe14: sai4_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf11: sai4_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pg9: sai4_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pg10: sai4_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h733vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733vghx-pinctrl.dtsi
@@ -2122,6 +2122,192 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe0: sai4_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe6: sai4_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe11: sai4_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pe12: sai4_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pe13: sai4_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe14: sai4_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h733vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733vgtx-pinctrl.dtsi
@@ -2122,6 +2122,192 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe0: sai4_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe6: sai4_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe11: sai4_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pe12: sai4_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pe13: sai4_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe14: sai4_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h733zgix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733zgix-pinctrl.dtsi
@@ -2806,6 +2806,248 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe0: sai4_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe6: sai4_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe11: sai4_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pe12: sai4_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pe13: sai4_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe14: sai4_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf11: sai4_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pg9: sai4_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pg10: sai4_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h733zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733zgtx-pinctrl.dtsi
@@ -2778,6 +2778,248 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe0: sai4_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe6: sai4_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe11: sai4_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pe12: sai4_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pe13: sai4_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe14: sai4_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf11: sai4_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pg9: sai4_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pg10: sai4_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h735agix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735agix-pinctrl.dtsi
@@ -3129,6 +3129,264 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0_c: sai4_sd_b_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1_c: sai4_mclk_b_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe0: sai4_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe6: sai4_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe11: sai4_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pe12: sai4_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pe13: sai4_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe14: sai4_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf11: sai4_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pg9: sai4_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pg10: sai4_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_ph2: sai4_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_ph3: sai4_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h735igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735igkx-pinctrl.dtsi
@@ -3279,6 +3279,264 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0_c: sai4_sd_b_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1_c: sai4_mclk_b_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe0: sai4_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe6: sai4_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe11: sai4_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pe12: sai4_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pe13: sai4_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe14: sai4_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf11: sai4_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pg9: sai4_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pg10: sai4_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_ph2: sai4_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_ph3: sai4_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h735igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735igtx-pinctrl.dtsi
@@ -2834,6 +2834,248 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe0: sai4_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe6: sai4_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe11: sai4_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pe12: sai4_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pe13: sai4_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe14: sai4_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf11: sai4_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pg9: sai4_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pg10: sai4_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h735vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vghx-pinctrl.dtsi
@@ -2032,6 +2032,176 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe0: sai4_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe6: sai4_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h735vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vgtx-pinctrl.dtsi
@@ -1871,6 +1871,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h735vgyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vgyx-pinctrl.dtsi
@@ -1785,6 +1785,116 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe0: sai4_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h735zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735zgtx-pinctrl.dtsi
@@ -2506,6 +2506,248 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa0: sai4_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pa1: sai4_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pa2: sai4_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa12: sai4_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pc0: sai4_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF1)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd11: sai4_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pd12: sai4_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pd13: sai4_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe0: sai4_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe6: sai4_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe11: sai4_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pe12: sai4_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pe13: sai4_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe14: sai4_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf11: sai4_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pg9: sai4_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pg10: sai4_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
@@ -2382,6 +2382,296 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
@@ -2666,6 +2666,304 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
@@ -2554,6 +2554,304 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
@@ -2554,6 +2554,304 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
@@ -1632,6 +1632,224 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
@@ -1632,6 +1632,224 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
@@ -2809,6 +2809,312 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0_c: sai2_sd_b_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1_c: sai2_mclk_b_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
@@ -2127,6 +2127,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
@@ -2656,6 +2656,296 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
@@ -3084,6 +3084,304 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bitx-pinctrl.dtsi
@@ -3084,6 +3084,304 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igkx-pinctrl.dtsi
@@ -2844,6 +2844,304 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igtx-pinctrl.dtsi
@@ -2844,6 +2844,304 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iikx-pinctrl.dtsi
@@ -2844,6 +2844,304 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iitx-pinctrl.dtsi
@@ -2844,6 +2844,304 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
@@ -1790,6 +1790,224 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
@@ -1790,6 +1790,224 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vitx-pinctrl.dtsi
@@ -1790,6 +1790,224 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xghx-pinctrl.dtsi
@@ -3225,6 +3225,312 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0_c: sai2_sd_b_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1_c: sai2_mclk_b_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xihx-pinctrl.dtsi
@@ -3225,6 +3225,312 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0_c: sai2_sd_b_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1_c: sai2_mclk_b_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
@@ -2329,6 +2329,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zitx-pinctrl.dtsi
@@ -2329,6 +2329,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
@@ -2928,6 +2928,304 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h745bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bitx-pinctrl.dtsi
@@ -2928,6 +2928,304 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h745igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igkx-pinctrl.dtsi
@@ -2799,6 +2799,296 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0_c: sai2_sd_b_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1_c: sai2_mclk_b_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h745igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igtx-pinctrl.dtsi
@@ -2385,6 +2385,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h745iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iikx-pinctrl.dtsi
@@ -2799,6 +2799,296 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0_c: sai2_sd_b_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1_c: sai2_mclk_b_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h745iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iitx-pinctrl.dtsi
@@ -2385,6 +2385,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h745xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xghx-pinctrl.dtsi
@@ -3225,6 +3225,312 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0_c: sai2_sd_b_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1_c: sai2_mclk_b_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h745xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xihx-pinctrl.dtsi
@@ -3225,6 +3225,312 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0_c: sai2_sd_b_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1_c: sai2_mclk_b_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
@@ -2120,6 +2120,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h745zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zitx-pinctrl.dtsi
@@ -2120,6 +2120,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
@@ -2329,6 +2329,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
@@ -2856,6 +2856,304 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h747bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bitx-pinctrl.dtsi
@@ -2856,6 +2856,304 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h747igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747igtx-pinctrl.dtsi
@@ -2329,6 +2329,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h747iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747iitx-pinctrl.dtsi
@@ -2329,6 +2329,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h747xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xghx-pinctrl.dtsi
@@ -3225,6 +3225,312 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0_c: sai2_sd_b_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1_c: sai2_mclk_b_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h747xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xihx-pinctrl.dtsi
@@ -3225,6 +3225,312 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0_c: sai2_sd_b_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1_c: sai2_mclk_b_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
@@ -2073,6 +2073,228 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
@@ -2844,6 +2844,304 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
@@ -2844,6 +2844,304 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
@@ -1790,6 +1790,224 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
@@ -3225,6 +3225,312 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0_c: sai2_sd_b_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1_c: sai2_mclk_b_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
@@ -2329,6 +2329,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h753aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753aiix-pinctrl.dtsi
@@ -2656,6 +2656,296 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h753bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753bitx-pinctrl.dtsi
@@ -3084,6 +3084,304 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h753iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iikx-pinctrl.dtsi
@@ -2844,6 +2844,304 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h753iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iitx-pinctrl.dtsi
@@ -2844,6 +2844,304 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h753vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vihx-pinctrl.dtsi
@@ -1790,6 +1790,224 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h753vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vitx-pinctrl.dtsi
@@ -1790,6 +1790,224 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h753xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753xihx-pinctrl.dtsi
@@ -3225,6 +3225,312 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0_c: sai2_sd_b_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1_c: sai2_mclk_b_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h753zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753zitx-pinctrl.dtsi
@@ -2329,6 +2329,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h755bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755bitx-pinctrl.dtsi
@@ -2928,6 +2928,304 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h755iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iikx-pinctrl.dtsi
@@ -2799,6 +2799,296 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0_c: sai2_sd_b_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1_c: sai2_mclk_b_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h755iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iitx-pinctrl.dtsi
@@ -2385,6 +2385,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h755xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755xihx-pinctrl.dtsi
@@ -3225,6 +3225,312 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0_c: sai2_sd_b_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1_c: sai2_mclk_b_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h755zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755zitx-pinctrl.dtsi
@@ -2120,6 +2120,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h757aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757aiix-pinctrl.dtsi
@@ -2329,6 +2329,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h757bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757bitx-pinctrl.dtsi
@@ -2856,6 +2856,304 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h757iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757iitx-pinctrl.dtsi
@@ -2329,6 +2329,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h757xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757xihx-pinctrl.dtsi
@@ -3225,6 +3225,312 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0_c: sai2_sd_b_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1_c: sai2_mclk_b_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pf6: sai4_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pf7: sai4_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf8: sai4_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pf9: sai4_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
@@ -2073,6 +2073,228 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb2: sai4_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb2: sai4_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pc1: sai4_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pc1: sai4_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pd6: sai4_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pd6: sai4_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pe2: sai4_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pe2: sai4_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pe3: sai4_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pe4: sai4_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pe4: sai4_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pe5: sai4_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pe5: sai4_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pe6: sai4_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF9)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pe6: sai4_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF8)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
@@ -2706,6 +2706,180 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0_c: sai2_sd_b_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1_c: sai2_mclk_b_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
@@ -2905,6 +2905,188 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
@@ -2834,6 +2834,180 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0_c: sai2_sd_b_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1_c: sai2_mclk_b_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
@@ -2905,6 +2905,188 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
@@ -2484,6 +2484,164 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
@@ -3315,6 +3315,196 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0_c: sai2_sd_b_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1_c: sai2_mclk_b_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
@@ -3190,6 +3190,188 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3qiyxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3qiyxq-pinctrl.dtsi
@@ -2027,6 +2027,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3r(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3r(g-i)tx-pinctrl.dtsi
@@ -1176,6 +1176,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
@@ -1878,6 +1878,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
@@ -1788,6 +1788,112 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
@@ -1878,6 +1878,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
@@ -1646,6 +1646,88 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
@@ -2428,6 +2428,164 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
@@ -2189,6 +2189,164 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
@@ -2706,6 +2706,180 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0_c: sai2_sd_b_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1_c: sai2_mclk_b_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
@@ -2834,6 +2834,180 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0_c: sai2_sd_b_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1_c: sai2_mclk_b_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
@@ -2905,6 +2905,188 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b0rbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0rbtx-pinctrl.dtsi
@@ -1176,6 +1176,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
@@ -1878,6 +1878,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
@@ -2428,6 +2428,164 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
@@ -2706,6 +2706,180 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0_c: sai2_sd_b_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1_c: sai2_mclk_b_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
@@ -2905,6 +2905,188 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
@@ -2834,6 +2834,180 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0_c: sai2_sd_b_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1_c: sai2_mclk_b_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
@@ -2905,6 +2905,188 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
@@ -2484,6 +2484,164 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
@@ -3315,6 +3315,196 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0_c: sai2_sd_b_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1_c: sai2_mclk_b_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
@@ -3190,6 +3190,188 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3qiyxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3qiyxq-pinctrl.dtsi
@@ -2027,6 +2027,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3ritx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3ritx-pinctrl.dtsi
@@ -1176,6 +1176,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
@@ -1878,6 +1878,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
@@ -1788,6 +1788,112 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
@@ -1878,6 +1878,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
@@ -1646,6 +1646,88 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
@@ -2428,6 +2428,164 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
@@ -2189,6 +2189,164 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7r3a8ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3a8ix-pinctrl.dtsi
@@ -1489,6 +1489,148 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pd6: sai1_sck_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {
@@ -2819,6 +2961,11 @@
 
 			/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 				pinmux = <STM32_PINMUX('O', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_ncs2_po1: xspim_p1_ncs2_po1 {
+				pinmux = <STM32_PINMUX('O', 1, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7r3i8kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3i8kx-pinctrl.dtsi
@@ -1567,6 +1567,156 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pd6: sai1_sck_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {
@@ -2933,6 +3083,11 @@
 
 			/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 				pinmux = <STM32_PINMUX('O', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_ncs2_po1: xspim_p1_ncs2_po1 {
+				pinmux = <STM32_PINMUX('O', 1, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7r3i8tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3i8tx-pinctrl.dtsi
@@ -1531,6 +1531,156 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pd6: sai1_sck_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {
@@ -2874,6 +3024,11 @@
 
 			/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 				pinmux = <STM32_PINMUX('O', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_ncs2_po1: xspim_p1_ncs2_po1 {
+				pinmux = <STM32_PINMUX('O', 1, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7r3l8hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3l8hx-pinctrl.dtsi
@@ -1890,6 +1890,168 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pd6: sai1_sck_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {
@@ -3421,8 +3583,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ xspim_p2_ncs2_pn12: xspim_p2_ncs2_pn12 {
+				pinmux = <STM32_PINMUX('N', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 				pinmux = <STM32_PINMUX('O', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_ncs2_po1: xspim_p1_ncs2_po1 {
+				pinmux = <STM32_PINMUX('O', 1, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7r3l8hxh-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3l8hxh-pinctrl.dtsi
@@ -1798,6 +1798,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pd6: sai1_sck_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {
@@ -3276,8 +3422,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ xspim_p2_ncs2_pn12: xspim_p2_ncs2_pn12 {
+				pinmux = <STM32_PINMUX('N', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 				pinmux = <STM32_PINMUX('O', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_ncs2_po1: xspim_p1_ncs2_po1 {
+				pinmux = <STM32_PINMUX('O', 1, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -3338,6 +3494,46 @@
 
 			/omit-if-no-ref/ xspim_p1_io7_pp7: xspim_p1_io7_pp7 {
 				pinmux = <STM32_PINMUX('P', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_io8_pp8: xspim_p1_io8_pp8 {
+				pinmux = <STM32_PINMUX('P', 8, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_io9_pp9: xspim_p1_io9_pp9 {
+				pinmux = <STM32_PINMUX('P', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_io10_pp10: xspim_p1_io10_pp10 {
+				pinmux = <STM32_PINMUX('P', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_io11_pp11: xspim_p1_io11_pp11 {
+				pinmux = <STM32_PINMUX('P', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_io12_pp12: xspim_p1_io12_pp12 {
+				pinmux = <STM32_PINMUX('P', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_io13_pp13: xspim_p1_io13_pp13 {
+				pinmux = <STM32_PINMUX('P', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_io14_pp14: xspim_p1_io14_pp14 {
+				pinmux = <STM32_PINMUX('P', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_io15_pp15: xspim_p1_io15_pp15 {
+				pinmux = <STM32_PINMUX('P', 15, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7r3r8vx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3r8vx-pinctrl.dtsi
@@ -635,6 +635,24 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/h7/stm32h7r3v8hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3v8hx-pinctrl.dtsi
@@ -799,6 +799,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
@@ -1489,6 +1511,11 @@
 
 			/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 				pinmux = <STM32_PINMUX('O', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_ncs2_po1: xspim_p1_ncs2_po1 {
+				pinmux = <STM32_PINMUX('O', 1, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7r3v8tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3v8tx-pinctrl.dtsi
@@ -840,6 +840,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
@@ -1639,6 +1661,11 @@
 
 			/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 				pinmux = <STM32_PINMUX('O', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_ncs2_po1: xspim_p1_ncs2_po1 {
+				pinmux = <STM32_PINMUX('O', 1, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7r3v8yx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3v8yx-pinctrl.dtsi
@@ -790,6 +790,32 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
@@ -1474,6 +1500,11 @@
 
 			/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 				pinmux = <STM32_PINMUX('O', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_ncs2_po1: xspim_p1_ncs2_po1 {
+				pinmux = <STM32_PINMUX('O', 1, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7r3z8jx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3z8jx-pinctrl.dtsi
@@ -1234,6 +1234,112 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pd6: sai1_sck_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {
@@ -2395,6 +2501,11 @@
 
 			/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 				pinmux = <STM32_PINMUX('O', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_ncs2_po1: xspim_p1_ncs2_po1 {
+				pinmux = <STM32_PINMUX('O', 1, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7r3z8tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3z8tx-pinctrl.dtsi
@@ -1294,6 +1294,112 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pd6: sai1_sck_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {
@@ -2482,6 +2588,11 @@
 
 			/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 				pinmux = <STM32_PINMUX('O', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_ncs2_po1: xspim_p1_ncs2_po1 {
+				pinmux = <STM32_PINMUX('O', 1, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7r7a8ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r7a8ix-pinctrl.dtsi
@@ -1701,6 +1701,140 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pd6: sai1_sck_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {
@@ -3011,8 +3145,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ xspim_p2_ncs2_pn12: xspim_p2_ncs2_pn12 {
+				pinmux = <STM32_PINMUX('N', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 				pinmux = <STM32_PINMUX('O', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_ncs2_po1: xspim_p1_ncs2_po1 {
+				pinmux = <STM32_PINMUX('O', 1, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7r7i8kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r7i8kx-pinctrl.dtsi
@@ -1770,6 +1770,144 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pd6: sai1_sck_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {
@@ -3101,6 +3239,11 @@
 
 			/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 				pinmux = <STM32_PINMUX('O', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_ncs2_po1: xspim_p1_ncs2_po1 {
+				pinmux = <STM32_PINMUX('O', 1, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7r7i8tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r7i8tx-pinctrl.dtsi
@@ -1709,6 +1709,144 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pd6: sai1_sck_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {
@@ -3016,6 +3154,11 @@
 
 			/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 				pinmux = <STM32_PINMUX('O', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_ncs2_po1: xspim_p1_ncs2_po1 {
+				pinmux = <STM32_PINMUX('O', 1, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7r7l8hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r7l8hx-pinctrl.dtsi
@@ -2088,6 +2088,168 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pd6: sai1_sck_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {
@@ -3619,8 +3781,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ xspim_p2_ncs2_pn12: xspim_p2_ncs2_pn12 {
+				pinmux = <STM32_PINMUX('N', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 				pinmux = <STM32_PINMUX('O', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_ncs2_po1: xspim_p1_ncs2_po1 {
+				pinmux = <STM32_PINMUX('O', 1, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7r7l8hxh-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r7l8hxh-pinctrl.dtsi
@@ -1980,6 +1980,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pd6: sai1_sck_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {
@@ -3458,8 +3604,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ xspim_p2_ncs2_pn12: xspim_p2_ncs2_pn12 {
+				pinmux = <STM32_PINMUX('N', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 				pinmux = <STM32_PINMUX('O', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_ncs2_po1: xspim_p1_ncs2_po1 {
+				pinmux = <STM32_PINMUX('O', 1, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -3520,6 +3676,46 @@
 
 			/omit-if-no-ref/ xspim_p1_io7_pp7: xspim_p1_io7_pp7 {
 				pinmux = <STM32_PINMUX('P', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_io8_pp8: xspim_p1_io8_pp8 {
+				pinmux = <STM32_PINMUX('P', 8, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_io9_pp9: xspim_p1_io9_pp9 {
+				pinmux = <STM32_PINMUX('P', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_io10_pp10: xspim_p1_io10_pp10 {
+				pinmux = <STM32_PINMUX('P', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_io11_pp11: xspim_p1_io11_pp11 {
+				pinmux = <STM32_PINMUX('P', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_io12_pp12: xspim_p1_io12_pp12 {
+				pinmux = <STM32_PINMUX('P', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_io13_pp13: xspim_p1_io13_pp13 {
+				pinmux = <STM32_PINMUX('P', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_io14_pp14: xspim_p1_io14_pp14 {
+				pinmux = <STM32_PINMUX('P', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_io15_pp15: xspim_p1_io15_pp15 {
+				pinmux = <STM32_PINMUX('P', 15, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7r7z8jx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r7z8jx-pinctrl.dtsi
@@ -1397,6 +1397,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pd6: sai1_sck_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
@@ -2405,6 +2495,11 @@
 
 			/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 				pinmux = <STM32_PINMUX('O', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_ncs2_po1: xspim_p1_ncs2_po1 {
+				pinmux = <STM32_PINMUX('O', 1, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7s3a8ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3a8ix-pinctrl.dtsi
@@ -1489,6 +1489,148 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pd6: sai1_sck_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {
@@ -2819,6 +2961,11 @@
 
 			/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 				pinmux = <STM32_PINMUX('O', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_ncs2_po1: xspim_p1_ncs2_po1 {
+				pinmux = <STM32_PINMUX('O', 1, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7s3i8kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3i8kx-pinctrl.dtsi
@@ -1567,6 +1567,156 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pd6: sai1_sck_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {
@@ -2933,6 +3083,11 @@
 
 			/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 				pinmux = <STM32_PINMUX('O', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_ncs2_po1: xspim_p1_ncs2_po1 {
+				pinmux = <STM32_PINMUX('O', 1, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7s3i8tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3i8tx-pinctrl.dtsi
@@ -1531,6 +1531,156 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pd6: sai1_sck_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {
@@ -2874,6 +3024,11 @@
 
 			/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 				pinmux = <STM32_PINMUX('O', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_ncs2_po1: xspim_p1_ncs2_po1 {
+				pinmux = <STM32_PINMUX('O', 1, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7s3l8hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3l8hx-pinctrl.dtsi
@@ -1890,6 +1890,168 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pd6: sai1_sck_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {
@@ -3421,8 +3583,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ xspim_p2_ncs2_pn12: xspim_p2_ncs2_pn12 {
+				pinmux = <STM32_PINMUX('N', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 				pinmux = <STM32_PINMUX('O', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_ncs2_po1: xspim_p1_ncs2_po1 {
+				pinmux = <STM32_PINMUX('O', 1, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7s3l8hxh-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3l8hxh-pinctrl.dtsi
@@ -1798,6 +1798,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pd6: sai1_sck_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {
@@ -3276,8 +3422,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ xspim_p2_ncs2_pn12: xspim_p2_ncs2_pn12 {
+				pinmux = <STM32_PINMUX('N', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 				pinmux = <STM32_PINMUX('O', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_ncs2_po1: xspim_p1_ncs2_po1 {
+				pinmux = <STM32_PINMUX('O', 1, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -3338,6 +3494,46 @@
 
 			/omit-if-no-ref/ xspim_p1_io7_pp7: xspim_p1_io7_pp7 {
 				pinmux = <STM32_PINMUX('P', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_io8_pp8: xspim_p1_io8_pp8 {
+				pinmux = <STM32_PINMUX('P', 8, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_io9_pp9: xspim_p1_io9_pp9 {
+				pinmux = <STM32_PINMUX('P', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_io10_pp10: xspim_p1_io10_pp10 {
+				pinmux = <STM32_PINMUX('P', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_io11_pp11: xspim_p1_io11_pp11 {
+				pinmux = <STM32_PINMUX('P', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_io12_pp12: xspim_p1_io12_pp12 {
+				pinmux = <STM32_PINMUX('P', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_io13_pp13: xspim_p1_io13_pp13 {
+				pinmux = <STM32_PINMUX('P', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_io14_pp14: xspim_p1_io14_pp14 {
+				pinmux = <STM32_PINMUX('P', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_io15_pp15: xspim_p1_io15_pp15 {
+				pinmux = <STM32_PINMUX('P', 15, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7s3r8vx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3r8vx-pinctrl.dtsi
@@ -635,6 +635,24 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/h7/stm32h7s3v8hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3v8hx-pinctrl.dtsi
@@ -799,6 +799,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
@@ -1489,6 +1511,11 @@
 
 			/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 				pinmux = <STM32_PINMUX('O', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_ncs2_po1: xspim_p1_ncs2_po1 {
+				pinmux = <STM32_PINMUX('O', 1, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7s3v8tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3v8tx-pinctrl.dtsi
@@ -840,6 +840,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
@@ -1639,6 +1661,11 @@
 
 			/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 				pinmux = <STM32_PINMUX('O', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_ncs2_po1: xspim_p1_ncs2_po1 {
+				pinmux = <STM32_PINMUX('O', 1, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7s3v8yx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3v8yx-pinctrl.dtsi
@@ -790,6 +790,32 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
@@ -1474,6 +1500,11 @@
 
 			/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 				pinmux = <STM32_PINMUX('O', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_ncs2_po1: xspim_p1_ncs2_po1 {
+				pinmux = <STM32_PINMUX('O', 1, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7s3z8jx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3z8jx-pinctrl.dtsi
@@ -1234,6 +1234,112 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pd6: sai1_sck_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {
@@ -2395,6 +2501,11 @@
 
 			/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 				pinmux = <STM32_PINMUX('O', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_ncs2_po1: xspim_p1_ncs2_po1 {
+				pinmux = <STM32_PINMUX('O', 1, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7s3z8tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3z8tx-pinctrl.dtsi
@@ -1294,6 +1294,112 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pd6: sai1_sck_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {
@@ -2482,6 +2588,11 @@
 
 			/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 				pinmux = <STM32_PINMUX('O', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_ncs2_po1: xspim_p1_ncs2_po1 {
+				pinmux = <STM32_PINMUX('O', 1, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7s7a8ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s7a8ix-pinctrl.dtsi
@@ -1701,6 +1701,140 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pd6: sai1_sck_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {
@@ -3011,8 +3145,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ xspim_p2_ncs2_pn12: xspim_p2_ncs2_pn12 {
+				pinmux = <STM32_PINMUX('N', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 				pinmux = <STM32_PINMUX('O', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_ncs2_po1: xspim_p1_ncs2_po1 {
+				pinmux = <STM32_PINMUX('O', 1, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7s7i8kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s7i8kx-pinctrl.dtsi
@@ -1770,6 +1770,144 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pd6: sai1_sck_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {
@@ -3101,6 +3239,11 @@
 
 			/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 				pinmux = <STM32_PINMUX('O', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_ncs2_po1: xspim_p1_ncs2_po1 {
+				pinmux = <STM32_PINMUX('O', 1, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7s7i8tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s7i8tx-pinctrl.dtsi
@@ -1709,6 +1709,144 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pd6: sai1_sck_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {
@@ -3016,6 +3154,11 @@
 
 			/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 				pinmux = <STM32_PINMUX('O', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_ncs2_po1: xspim_p1_ncs2_po1 {
+				pinmux = <STM32_PINMUX('O', 1, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7s7l8hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s7l8hx-pinctrl.dtsi
@@ -2088,6 +2088,168 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pd6: sai1_sck_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {
@@ -3619,8 +3781,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ xspim_p2_ncs2_pn12: xspim_p2_ncs2_pn12 {
+				pinmux = <STM32_PINMUX('N', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 				pinmux = <STM32_PINMUX('O', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_ncs2_po1: xspim_p1_ncs2_po1 {
+				pinmux = <STM32_PINMUX('O', 1, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7s7l8hxh-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s7l8hxh-pinctrl.dtsi
@@ -1980,6 +1980,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pd6: sai1_sck_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {
@@ -3458,8 +3604,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ xspim_p2_ncs2_pn12: xspim_p2_ncs2_pn12 {
+				pinmux = <STM32_PINMUX('N', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 				pinmux = <STM32_PINMUX('O', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_ncs2_po1: xspim_p1_ncs2_po1 {
+				pinmux = <STM32_PINMUX('O', 1, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -3520,6 +3676,46 @@
 
 			/omit-if-no-ref/ xspim_p1_io7_pp7: xspim_p1_io7_pp7 {
 				pinmux = <STM32_PINMUX('P', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_io8_pp8: xspim_p1_io8_pp8 {
+				pinmux = <STM32_PINMUX('P', 8, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_io9_pp9: xspim_p1_io9_pp9 {
+				pinmux = <STM32_PINMUX('P', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_io10_pp10: xspim_p1_io10_pp10 {
+				pinmux = <STM32_PINMUX('P', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_io11_pp11: xspim_p1_io11_pp11 {
+				pinmux = <STM32_PINMUX('P', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_io12_pp12: xspim_p1_io12_pp12 {
+				pinmux = <STM32_PINMUX('P', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_io13_pp13: xspim_p1_io13_pp13 {
+				pinmux = <STM32_PINMUX('P', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_io14_pp14: xspim_p1_io14_pp14 {
+				pinmux = <STM32_PINMUX('P', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_io15_pp15: xspim_p1_io15_pp15 {
+				pinmux = <STM32_PINMUX('P', 15, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7s7z8jx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s7z8jx-pinctrl.dtsi
@@ -1397,6 +1397,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pd6: sai1_sck_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
@@ -2405,6 +2495,11 @@
 
 			/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 				pinmux = <STM32_PINMUX('O', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ xspim_p1_ncs2_po1: xspim_p1_ncs2_po1 {
+				pinmux = <STM32_PINMUX('O', 1, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l431c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431c(b-c)tx-pinctrl.dtsi
@@ -412,6 +412,88 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l431c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431c(b-c)ux-pinctrl.dtsi
@@ -412,6 +412,88 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l431c(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431c(b-c)yx-pinctrl.dtsi
@@ -420,6 +420,92 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l431k(b-c)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431k(b-c)ux-pinctrl.dtsi
@@ -299,6 +299,60 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l431r(b-c)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431r(b-c)ix-pinctrl.dtsi
@@ -504,6 +504,92 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l431r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431r(b-c)tx-pinctrl.dtsi
@@ -504,6 +504,92 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l431r(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431r(b-c)yx-pinctrl.dtsi
@@ -504,6 +504,92 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l431vcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431vcix-pinctrl.dtsi
@@ -692,6 +692,132 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l431vctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431vctx-pinctrl.dtsi
@@ -692,6 +692,132 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l432k(b-c)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l432k(b-c)ux-pinctrl.dtsi
@@ -299,6 +299,60 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l433c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433c(b-c)tx-pinctrl.dtsi
@@ -412,6 +412,88 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l433c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433c(b-c)ux-pinctrl.dtsi
@@ -412,6 +412,88 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l433c(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433c(b-c)yx-pinctrl.dtsi
@@ -420,6 +420,92 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l433r(b-c)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433r(b-c)ix-pinctrl.dtsi
@@ -504,6 +504,92 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l433r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433r(b-c)tx-pinctrl.dtsi
@@ -504,6 +504,92 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l433r(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433r(b-c)yx-pinctrl.dtsi
@@ -504,6 +504,92 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l433rctxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433rctxp-pinctrl.dtsi
@@ -492,6 +492,92 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l433vcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433vcix-pinctrl.dtsi
@@ -692,6 +692,132 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l433vctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433vctx-pinctrl.dtsi
@@ -692,6 +692,132 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l442kcux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l442kcux-pinctrl.dtsi
@@ -299,6 +299,60 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l443ccfx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443ccfx-pinctrl.dtsi
@@ -420,6 +420,92 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l443cctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443cctx-pinctrl.dtsi
@@ -412,6 +412,88 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l443ccux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443ccux-pinctrl.dtsi
@@ -412,6 +412,88 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l443ccyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443ccyx-pinctrl.dtsi
@@ -420,6 +420,92 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l443rcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443rcix-pinctrl.dtsi
@@ -504,6 +504,92 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l443rctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443rctx-pinctrl.dtsi
@@ -504,6 +504,92 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l443rcyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443rcyx-pinctrl.dtsi
@@ -504,6 +504,92 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l443vcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443vcix-pinctrl.dtsi
@@ -692,6 +692,132 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l443vctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443vctx-pinctrl.dtsi
@@ -692,6 +692,132 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l451c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451c(c-e)ux-pinctrl.dtsi
@@ -512,6 +512,88 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l451cetx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451cetx-pinctrl.dtsi
@@ -512,6 +512,88 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l451r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451r(c-e)ix-pinctrl.dtsi
@@ -631,6 +631,92 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l451r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451r(c-e)tx-pinctrl.dtsi
@@ -631,6 +631,92 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l451r(c-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451r(c-e)yx-pinctrl.dtsi
@@ -631,6 +631,92 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l451v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451v(c-e)ix-pinctrl.dtsi
@@ -881,6 +881,132 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l451v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451v(c-e)tx-pinctrl.dtsi
@@ -881,6 +881,132 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l452c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452c(c-e)ux-pinctrl.dtsi
@@ -512,6 +512,88 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l452cetx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452cetx-pinctrl.dtsi
@@ -512,6 +512,88 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l452cetxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452cetxp-pinctrl.dtsi
@@ -512,6 +512,88 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l452r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452r(c-e)ix-pinctrl.dtsi
@@ -631,6 +631,92 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l452r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452r(c-e)tx-pinctrl.dtsi
@@ -631,6 +631,92 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l452r(c-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452r(c-e)yx-pinctrl.dtsi
@@ -631,6 +631,92 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l452retxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452retxp-pinctrl.dtsi
@@ -619,6 +619,92 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l452reyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452reyxp-pinctrl.dtsi
@@ -631,6 +631,92 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l452v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452v(c-e)ix-pinctrl.dtsi
@@ -881,6 +881,132 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l452v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452v(c-e)tx-pinctrl.dtsi
@@ -881,6 +881,132 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l462cetx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462cetx-pinctrl.dtsi
@@ -512,6 +512,88 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l462ceux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462ceux-pinctrl.dtsi
@@ -512,6 +512,88 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l462reix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462reix-pinctrl.dtsi
@@ -631,6 +631,92 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l462retx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462retx-pinctrl.dtsi
@@ -631,6 +631,92 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l462reyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462reyx-pinctrl.dtsi
@@ -631,6 +631,92 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l462veix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462veix-pinctrl.dtsi
@@ -881,6 +881,132 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l462vetx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462vetx-pinctrl.dtsi
@@ -881,6 +881,132 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l471q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471q(e-g)ix-pinctrl.dtsi
@@ -1362,6 +1362,184 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l471r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471r(e-g)tx-pinctrl.dtsi
@@ -623,6 +623,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l471v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471v(e-g)tx-pinctrl.dtsi
@@ -1055,6 +1055,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l471z(e-g)jx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471z(e-g)jx-pinctrl.dtsi
@@ -1402,6 +1402,200 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l471z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471z(e-g)tx-pinctrl.dtsi
@@ -1402,6 +1402,200 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l475r(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l475r(c-e-g)tx-pinctrl.dtsi
@@ -623,6 +623,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l475v(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l475v(c-e-g)tx-pinctrl.dtsi
@@ -1055,6 +1055,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l476j(e-g)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476j(e-g)yx-pinctrl.dtsi
@@ -659,6 +659,112 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l476jgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476jgyxp-pinctrl.dtsi
@@ -643,6 +643,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l476m(e-g)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476m(e-g)yx-pinctrl.dtsi
@@ -716,6 +716,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l476q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476q(e-g)ix-pinctrl.dtsi
@@ -1362,6 +1362,184 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l476qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476qgixp-pinctrl.dtsi
@@ -1362,6 +1362,184 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l476r(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476r(c-e-g)tx-pinctrl.dtsi
@@ -623,6 +623,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l476v(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476v(c-e-g)tx-pinctrl.dtsi
@@ -1055,6 +1055,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l476vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476vgyxp-pinctrl.dtsi
@@ -719,6 +719,136 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l476z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476z(e-g)tx-pinctrl.dtsi
@@ -1402,6 +1402,200 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l476zgjx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476zgjx-pinctrl.dtsi
@@ -1402,6 +1402,200 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l476zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476zgtxp-pinctrl.dtsi
@@ -1373,6 +1373,200 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l485j(c-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l485j(c-e)yx-pinctrl.dtsi
@@ -659,6 +659,112 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l486jgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486jgyx-pinctrl.dtsi
@@ -659,6 +659,112 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l486qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486qgix-pinctrl.dtsi
@@ -1362,6 +1362,184 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l486rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486rgtx-pinctrl.dtsi
@@ -623,6 +623,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l486vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486vgtx-pinctrl.dtsi
@@ -1055,6 +1055,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l486zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486zgtx-pinctrl.dtsi
@@ -1402,6 +1402,200 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l496a(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496a(e-g)ix-pinctrl.dtsi
@@ -1887,6 +1887,220 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l496agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496agixp-pinctrl.dtsi
@@ -1869,6 +1869,220 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l496q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496q(e-g)ix-pinctrl.dtsi
@@ -1671,6 +1671,220 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l496qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496qgixp-pinctrl.dtsi
@@ -1629,6 +1629,220 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l496qgixs-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496qgixs-pinctrl.dtsi
@@ -1671,6 +1671,220 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l496r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496r(e-g)tx-pinctrl.dtsi
@@ -816,6 +816,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l496rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496rgtxp-pinctrl.dtsi
@@ -800,6 +800,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l496v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496v(e-g)tx-pinctrl.dtsi
@@ -1335,6 +1335,184 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l496vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgtxp-pinctrl.dtsi
@@ -1294,6 +1294,184 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l496vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgyx-pinctrl.dtsi
@@ -1255,6 +1255,192 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l496vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgyxp-pinctrl.dtsi
@@ -1243,6 +1243,192 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l496wgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496wgyxp-pinctrl.dtsi
@@ -1366,6 +1366,204 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d5_pb9: sdmmc1_d5_pb9 {

--- a/dts/st/l4/stm32l496z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496z(e-g)tx-pinctrl.dtsi
@@ -1736,6 +1736,236 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l496zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496zgtxp-pinctrl.dtsi
@@ -1701,6 +1701,236 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l4a6agix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6agix-pinctrl.dtsi
@@ -1887,6 +1887,220 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l4a6agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6agixp-pinctrl.dtsi
@@ -1869,6 +1869,220 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l4a6qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6qgix-pinctrl.dtsi
@@ -1671,6 +1671,220 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l4a6qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6qgixp-pinctrl.dtsi
@@ -1629,6 +1629,220 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l4a6rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6rgtx-pinctrl.dtsi
@@ -816,6 +816,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l4a6rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6rgtxp-pinctrl.dtsi
@@ -800,6 +800,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l4a6vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgtx-pinctrl.dtsi
@@ -1335,6 +1335,184 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l4a6vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgtxp-pinctrl.dtsi
@@ -1294,6 +1294,184 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l4a6vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgyx-pinctrl.dtsi
@@ -1255,6 +1255,192 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l4a6vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgyxp-pinctrl.dtsi
@@ -1243,6 +1243,192 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l4a6zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6zgtx-pinctrl.dtsi
@@ -1736,6 +1736,236 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l4a6zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6zgtxp-pinctrl.dtsi
@@ -1701,6 +1701,236 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l4p5a(g-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5a(g-e)ix-pinctrl.dtsi
@@ -2238,6 +2238,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4p5agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5agixp-pinctrl.dtsi
@@ -2210,6 +2210,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4p5c(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5c(g-e)tx-pinctrl.dtsi
@@ -624,6 +624,116 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc2_cmd_pa1: sdmmc2_cmd_pa1 {

--- a/dts/st/l4/stm32l4p5c(g-e)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5c(g-e)ux-pinctrl.dtsi
@@ -624,6 +624,116 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc2_cmd_pa1: sdmmc2_cmd_pa1 {

--- a/dts/st/l4/stm32l4p5cgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5cgtxp-pinctrl.dtsi
@@ -575,6 +575,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc2_cmd_pa1: sdmmc2_cmd_pa1 {

--- a/dts/st/l4/stm32l4p5cguxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5cguxp-pinctrl.dtsi
@@ -575,6 +575,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc2_cmd_pa1: sdmmc2_cmd_pa1 {

--- a/dts/st/l4/stm32l4p5q(g-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5q(g-e)ix-pinctrl.dtsi
@@ -1936,6 +1936,276 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4p5qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5qgixp-pinctrl.dtsi
@@ -1891,6 +1891,276 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4p5qgixs-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5qgixs-pinctrl.dtsi
@@ -1891,6 +1891,276 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4p5r(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5r(g-e)tx-pinctrl.dtsi
@@ -892,6 +892,160 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4p5rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5rgtxp-pinctrl.dtsi
@@ -872,6 +872,156 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4p5v(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5v(g-e)tx-pinctrl.dtsi
@@ -1500,6 +1500,236 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4p5v(g-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5v(g-e)yx-pinctrl.dtsi
@@ -1438,6 +1438,244 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4p5vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5vgtxp-pinctrl.dtsi
@@ -1456,6 +1456,236 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4p5vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5vgyxp-pinctrl.dtsi
@@ -1422,6 +1422,240 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4p5z(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5z(g-e)tx-pinctrl.dtsi
@@ -1986,6 +1986,296 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4p5zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5zgtxp-pinctrl.dtsi
@@ -1947,6 +1947,296 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4q5agix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5agix-pinctrl.dtsi
@@ -2238,6 +2238,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4q5agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5agixp-pinctrl.dtsi
@@ -2210,6 +2210,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4q5cgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cgtx-pinctrl.dtsi
@@ -624,6 +624,116 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc2_cmd_pa1: sdmmc2_cmd_pa1 {

--- a/dts/st/l4/stm32l4q5cgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cgtxp-pinctrl.dtsi
@@ -575,6 +575,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc2_cmd_pa1: sdmmc2_cmd_pa1 {

--- a/dts/st/l4/stm32l4q5cgux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cgux-pinctrl.dtsi
@@ -624,6 +624,116 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc2_cmd_pa1: sdmmc2_cmd_pa1 {

--- a/dts/st/l4/stm32l4q5cguxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cguxp-pinctrl.dtsi
@@ -575,6 +575,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc2_cmd_pa1: sdmmc2_cmd_pa1 {

--- a/dts/st/l4/stm32l4q5qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5qgix-pinctrl.dtsi
@@ -1936,6 +1936,276 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4q5qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5qgixp-pinctrl.dtsi
@@ -1891,6 +1891,276 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4q5rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5rgtx-pinctrl.dtsi
@@ -892,6 +892,160 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4q5rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5rgtxp-pinctrl.dtsi
@@ -872,6 +872,156 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4q5vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgtx-pinctrl.dtsi
@@ -1500,6 +1500,236 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4q5vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgtxp-pinctrl.dtsi
@@ -1456,6 +1456,236 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4q5vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgyx-pinctrl.dtsi
@@ -1438,6 +1438,244 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4q5vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgyxp-pinctrl.dtsi
@@ -1422,6 +1422,240 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4q5zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5zgtx-pinctrl.dtsi
@@ -1986,6 +1986,296 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4q5zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5zgtxp-pinctrl.dtsi
@@ -1947,6 +1947,296 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r5a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5a(g-i)ix-pinctrl.dtsi
@@ -1952,6 +1952,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r5aiixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5aiixp-pinctrl.dtsi
@@ -1952,6 +1952,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r5q(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5q(g-i)ix-pinctrl.dtsi
@@ -1660,6 +1660,276 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r5qgixs-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5qgixs-pinctrl.dtsi
@@ -1660,6 +1660,276 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r5qiixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5qiixp-pinctrl.dtsi
@@ -1660,6 +1660,276 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r5v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5v(g-i)tx-pinctrl.dtsi
@@ -1256,6 +1256,236 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r5z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5z(g-i)tx-pinctrl.dtsi
@@ -1710,6 +1710,296 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r5z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5z(g-i)yx-pinctrl.dtsi
@@ -1653,6 +1653,284 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r5zitxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5zitxp-pinctrl.dtsi
@@ -1670,6 +1670,296 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r7aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7aiix-pinctrl.dtsi
@@ -2110,6 +2110,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r7vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7vitx-pinctrl.dtsi
@@ -1382,6 +1382,236 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r7zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7zitx-pinctrl.dtsi
@@ -1868,6 +1868,296 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r9a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9a(g-i)ix-pinctrl.dtsi
@@ -2049,6 +2049,276 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r9v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9v(g-i)tx-pinctrl.dtsi
@@ -1275,6 +1275,224 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r9z(g-i)jx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)jx-pinctrl.dtsi
@@ -1825,6 +1825,292 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r9z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)tx-pinctrl.dtsi
@@ -1802,6 +1802,284 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r9z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)yx-pinctrl.dtsi
@@ -1807,6 +1807,284 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r9ziyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9ziyxp-pinctrl.dtsi
@@ -1761,6 +1761,284 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4s5aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5aiix-pinctrl.dtsi
@@ -1952,6 +1952,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4s5qiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5qiix-pinctrl.dtsi
@@ -1660,6 +1660,276 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4s5vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5vitx-pinctrl.dtsi
@@ -1256,6 +1256,236 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4s5zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5zitx-pinctrl.dtsi
@@ -1710,6 +1710,296 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4s5ziyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5ziyx-pinctrl.dtsi
@@ -1653,6 +1653,284 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4s7aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7aiix-pinctrl.dtsi
@@ -2110,6 +2110,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4s7vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7vitx-pinctrl.dtsi
@@ -1382,6 +1382,236 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4s7zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7zitx-pinctrl.dtsi
@@ -1868,6 +1868,296 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4s9aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9aiix-pinctrl.dtsi
@@ -2049,6 +2049,276 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4s9vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9vitx-pinctrl.dtsi
@@ -1275,6 +1275,224 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4s9zijx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9zijx-pinctrl.dtsi
@@ -1825,6 +1825,292 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4s9zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9zitx-pinctrl.dtsi
@@ -1802,6 +1802,284 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4s9ziyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9ziyx-pinctrl.dtsi
@@ -1807,6 +1807,284 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l552c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552c(c-e)tx-pinctrl.dtsi
@@ -529,6 +529,116 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l5/stm32l552c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552c(c-e)ux-pinctrl.dtsi
@@ -529,6 +529,116 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l5/stm32l552cetxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552cetxp-pinctrl.dtsi
@@ -494,6 +494,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l5/stm32l552ceuxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552ceuxp-pinctrl.dtsi
@@ -494,6 +494,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l5/stm32l552meyxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552meyxp-pinctrl.dtsi
@@ -755,6 +755,172 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l552meyxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552meyxq-pinctrl.dtsi
@@ -728,6 +728,172 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l552q(c-e)ixq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552q(c-e)ixq-pinctrl.dtsi
@@ -1428,6 +1428,272 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l552qeix-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552qeix-pinctrl.dtsi
@@ -1478,6 +1478,276 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l552qeixp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552qeixp-pinctrl.dtsi
@@ -1460,6 +1460,272 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l552r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552r(c-e)tx-pinctrl.dtsi
@@ -690,6 +690,160 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l552retxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552retxp-pinctrl.dtsi
@@ -674,6 +674,156 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l5/stm32l552retxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552retxq-pinctrl.dtsi
@@ -607,6 +607,144 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l552v(c-e)txq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552v(c-e)txq-pinctrl.dtsi
@@ -1086,6 +1086,228 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l552vetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552vetx-pinctrl.dtsi
@@ -1144,6 +1144,236 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l552z(c-e)txq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552z(c-e)txq-pinctrl.dtsi
@@ -1471,6 +1471,284 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l552zetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552zetx-pinctrl.dtsi
@@ -1528,6 +1528,296 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l562cetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562cetx-pinctrl.dtsi
@@ -529,6 +529,116 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l5/stm32l562cetxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562cetxp-pinctrl.dtsi
@@ -494,6 +494,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l5/stm32l562ceux-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562ceux-pinctrl.dtsi
@@ -529,6 +529,116 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l5/stm32l562ceuxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562ceuxp-pinctrl.dtsi
@@ -494,6 +494,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l5/stm32l562meyxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562meyxp-pinctrl.dtsi
@@ -755,6 +755,172 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l562meyxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562meyxq-pinctrl.dtsi
@@ -728,6 +728,172 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l562qeix-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeix-pinctrl.dtsi
@@ -1478,6 +1478,276 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l562qeixp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeixp-pinctrl.dtsi
@@ -1460,6 +1460,272 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l562qeixq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeixq-pinctrl.dtsi
@@ -1428,6 +1428,272 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l562retx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retx-pinctrl.dtsi
@@ -690,6 +690,160 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l562retxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retxp-pinctrl.dtsi
@@ -674,6 +674,156 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l5/stm32l562retxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retxq-pinctrl.dtsi
@@ -607,6 +607,144 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l562vetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562vetx-pinctrl.dtsi
@@ -1144,6 +1144,236 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l562vetxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562vetxq-pinctrl.dtsi
@@ -1086,6 +1086,228 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l562zetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562zetx-pinctrl.dtsi
@@ -1528,6 +1528,296 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l562zetxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562zetxq-pinctrl.dtsi
@@ -1471,6 +1471,284 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb0: sai1_extclk_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pa2: sai2_extclk_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_extclk_pc9: sai2_extclk_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/mp1/stm32mp131aaex-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp131aaex-pinctrl.dtsi
@@ -1748,6 +1748,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {

--- a/dts/st/mp1/stm32mp131aafx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp131aafx-pinctrl.dtsi
@@ -1748,6 +1748,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {

--- a/dts/st/mp1/stm32mp131aagx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp131aagx-pinctrl.dtsi
@@ -1748,6 +1748,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {

--- a/dts/st/mp1/stm32mp131caex-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp131caex-pinctrl.dtsi
@@ -1748,6 +1748,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {

--- a/dts/st/mp1/stm32mp131cafx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp131cafx-pinctrl.dtsi
@@ -1748,6 +1748,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {

--- a/dts/st/mp1/stm32mp131cagx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp131cagx-pinctrl.dtsi
@@ -1748,6 +1748,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {

--- a/dts/st/mp1/stm32mp131daex-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp131daex-pinctrl.dtsi
@@ -1748,6 +1748,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {

--- a/dts/st/mp1/stm32mp131dafx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp131dafx-pinctrl.dtsi
@@ -1748,6 +1748,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {

--- a/dts/st/mp1/stm32mp131dagx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp131dagx-pinctrl.dtsi
@@ -1748,6 +1748,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {

--- a/dts/st/mp1/stm32mp131faex-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp131faex-pinctrl.dtsi
@@ -1748,6 +1748,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {

--- a/dts/st/mp1/stm32mp131fafx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp131fafx-pinctrl.dtsi
@@ -1748,6 +1748,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {

--- a/dts/st/mp1/stm32mp131fagx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp131fagx-pinctrl.dtsi
@@ -1748,6 +1748,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {

--- a/dts/st/mp1/stm32mp133aaex-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp133aaex-pinctrl.dtsi
@@ -1912,6 +1912,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {

--- a/dts/st/mp1/stm32mp133aafx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp133aafx-pinctrl.dtsi
@@ -1912,6 +1912,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {

--- a/dts/st/mp1/stm32mp133aagx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp133aagx-pinctrl.dtsi
@@ -1912,6 +1912,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {

--- a/dts/st/mp1/stm32mp133caex-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp133caex-pinctrl.dtsi
@@ -1912,6 +1912,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {

--- a/dts/st/mp1/stm32mp133cafx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp133cafx-pinctrl.dtsi
@@ -1912,6 +1912,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {

--- a/dts/st/mp1/stm32mp133cagx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp133cagx-pinctrl.dtsi
@@ -1912,6 +1912,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {

--- a/dts/st/mp1/stm32mp133daex-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp133daex-pinctrl.dtsi
@@ -1912,6 +1912,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {

--- a/dts/st/mp1/stm32mp133dafx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp133dafx-pinctrl.dtsi
@@ -1912,6 +1912,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {

--- a/dts/st/mp1/stm32mp133dagx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp133dagx-pinctrl.dtsi
@@ -1912,6 +1912,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {

--- a/dts/st/mp1/stm32mp133faex-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp133faex-pinctrl.dtsi
@@ -1912,6 +1912,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {

--- a/dts/st/mp1/stm32mp133fafx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp133fafx-pinctrl.dtsi
@@ -1912,6 +1912,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {

--- a/dts/st/mp1/stm32mp133fagx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp133fagx-pinctrl.dtsi
@@ -1912,6 +1912,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {

--- a/dts/st/mp1/stm32mp135aaex-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp135aaex-pinctrl.dtsi
@@ -2378,6 +2378,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {

--- a/dts/st/mp1/stm32mp135aafx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp135aafx-pinctrl.dtsi
@@ -2378,6 +2378,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {

--- a/dts/st/mp1/stm32mp135aagx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp135aagx-pinctrl.dtsi
@@ -2378,6 +2378,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {

--- a/dts/st/mp1/stm32mp135caex-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp135caex-pinctrl.dtsi
@@ -2378,6 +2378,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {

--- a/dts/st/mp1/stm32mp135cafx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp135cafx-pinctrl.dtsi
@@ -2378,6 +2378,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {

--- a/dts/st/mp1/stm32mp135cagx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp135cagx-pinctrl.dtsi
@@ -2378,6 +2378,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {

--- a/dts/st/mp1/stm32mp135daex-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp135daex-pinctrl.dtsi
@@ -2378,6 +2378,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {

--- a/dts/st/mp1/stm32mp135dafx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp135dafx-pinctrl.dtsi
@@ -2378,6 +2378,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {

--- a/dts/st/mp1/stm32mp135dagx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp135dagx-pinctrl.dtsi
@@ -2378,6 +2378,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {

--- a/dts/st/mp1/stm32mp135faex-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp135faex-pinctrl.dtsi
@@ -2378,6 +2378,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {

--- a/dts/st/mp1/stm32mp135fafx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp135fafx-pinctrl.dtsi
@@ -2378,6 +2378,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {

--- a/dts/st/mp1/stm32mp135fagx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp135fagx-pinctrl.dtsi
@@ -2378,6 +2378,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {

--- a/dts/st/mp1/stm32mp151aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aaax-pinctrl.dtsi
@@ -2941,6 +2941,396 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_ph5: sai4_sd_b_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp151aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aabx-pinctrl.dtsi
@@ -1896,6 +1896,368 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp151aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aacx-pinctrl.dtsi
@@ -2701,6 +2701,396 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_ph5: sai4_sd_b_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp151aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aadx-pinctrl.dtsi
@@ -1896,6 +1896,368 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp151caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151caax-pinctrl.dtsi
@@ -2941,6 +2941,396 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_ph5: sai4_sd_b_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp151cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cabx-pinctrl.dtsi
@@ -1896,6 +1896,368 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp151cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cacx-pinctrl.dtsi
@@ -2701,6 +2701,396 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_ph5: sai4_sd_b_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp151cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cadx-pinctrl.dtsi
@@ -1896,6 +1896,368 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp151daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151daax-pinctrl.dtsi
@@ -2941,6 +2941,396 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_ph5: sai4_sd_b_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp151dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dabx-pinctrl.dtsi
@@ -1896,6 +1896,368 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp151dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dacx-pinctrl.dtsi
@@ -2701,6 +2701,396 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_ph5: sai4_sd_b_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp151dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dadx-pinctrl.dtsi
@@ -1896,6 +1896,368 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp151faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151faax-pinctrl.dtsi
@@ -2941,6 +2941,396 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_ph5: sai4_sd_b_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp151fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151fabx-pinctrl.dtsi
@@ -1896,6 +1896,368 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp151facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151facx-pinctrl.dtsi
@@ -2701,6 +2701,396 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_ph5: sai4_sd_b_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp151fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151fadx-pinctrl.dtsi
@@ -1896,6 +1896,368 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp153aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aaax-pinctrl.dtsi
@@ -2997,6 +2997,396 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_ph5: sai4_sd_b_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp153aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aabx-pinctrl.dtsi
@@ -1940,6 +1940,368 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp153aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aacx-pinctrl.dtsi
@@ -2757,6 +2757,396 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_ph5: sai4_sd_b_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp153aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aadx-pinctrl.dtsi
@@ -1940,6 +1940,368 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp153caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153caax-pinctrl.dtsi
@@ -2997,6 +2997,396 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_ph5: sai4_sd_b_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp153cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cabx-pinctrl.dtsi
@@ -1940,6 +1940,368 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp153cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cacx-pinctrl.dtsi
@@ -2757,6 +2757,396 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_ph5: sai4_sd_b_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp153cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cadx-pinctrl.dtsi
@@ -1940,6 +1940,368 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp153daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153daax-pinctrl.dtsi
@@ -2997,6 +2997,396 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_ph5: sai4_sd_b_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp153dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dabx-pinctrl.dtsi
@@ -1940,6 +1940,368 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp153dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dacx-pinctrl.dtsi
@@ -2757,6 +2757,396 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_ph5: sai4_sd_b_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp153dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dadx-pinctrl.dtsi
@@ -1940,6 +1940,368 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp153faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153faax-pinctrl.dtsi
@@ -2997,6 +2997,396 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_ph5: sai4_sd_b_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp153fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153fabx-pinctrl.dtsi
@@ -1940,6 +1940,368 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp153facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153facx-pinctrl.dtsi
@@ -2757,6 +2757,396 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_ph5: sai4_sd_b_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp153fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153fadx-pinctrl.dtsi
@@ -1940,6 +1940,368 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp157aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aaax-pinctrl.dtsi
@@ -2997,6 +2997,396 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_ph5: sai4_sd_b_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp157aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aabx-pinctrl.dtsi
@@ -1940,6 +1940,368 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp157aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aacx-pinctrl.dtsi
@@ -2757,6 +2757,396 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_ph5: sai4_sd_b_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp157aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aadx-pinctrl.dtsi
@@ -1940,6 +1940,368 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp157caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157caax-pinctrl.dtsi
@@ -2997,6 +2997,396 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_ph5: sai4_sd_b_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp157cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cabx-pinctrl.dtsi
@@ -1940,6 +1940,368 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp157cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cacx-pinctrl.dtsi
@@ -2757,6 +2757,396 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_ph5: sai4_sd_b_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp157cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cadx-pinctrl.dtsi
@@ -1940,6 +1940,368 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp157daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157daax-pinctrl.dtsi
@@ -2997,6 +2997,396 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_ph5: sai4_sd_b_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp157dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dabx-pinctrl.dtsi
@@ -1940,6 +1940,368 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp157dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dacx-pinctrl.dtsi
@@ -2757,6 +2757,396 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_ph5: sai4_sd_b_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp157dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dadx-pinctrl.dtsi
@@ -1940,6 +1940,368 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp157faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157faax-pinctrl.dtsi
@@ -2997,6 +2997,396 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_ph5: sai4_sd_b_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp157fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157fabx-pinctrl.dtsi
@@ -1940,6 +1940,368 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp157facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157facx-pinctrl.dtsi
@@ -2757,6 +2757,396 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_ph2: sai2_sck_b_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_ph3: sai2_mclk_b_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pi4: sai2_mclk_a_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pi5: sai2_sck_a_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pi6: sai2_sd_a_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pi7: sai2_fs_a_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_ph5: sai4_sd_b_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp157fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157fadx-pinctrl.dtsi
@@ -1940,6 +1940,368 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc1: sai1_d1_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf10: sai1_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pg13: sai1_ck2_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pg13: sai1_sck_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pg15: sai1_d2_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pg15: sai1_fs_a_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc0: sai2_fs_b_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe6: sai2_mclk_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg9: sai2_fs_b_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg10: sai2_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_a_pd0: sai3_sck_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_a_pd1: sai3_sd_a_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_a_pd4: sai3_fs_a_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sck_b_pd8: sai3_sck_b_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pd9: sai3_sd_b_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_fs_b_pd10: sai3_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_b_pd14: sai3_mclk_b_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_mclk_a_pd15: sai3_mclk_a_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai3_sd_b_pe1: sai3_sd_b_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa4: sai4_d2_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa4: sai4_fs_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pa5: sai4_ck1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pa5: sai4_mclk_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pa6: sai4_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pa6: sai4_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pa7: sai4_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pa7: sai4_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pa8: sai4_sd_b_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_b_pa10: sai4_fs_b_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pa15: sai4_d2_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pa15: sai4_fs_a_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pb3: sai4_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pb3: sai4_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pb4: sai4_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pb4: sai4_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pb5: sai4_d1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pb5: sai4_sd_a_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc5: sai4_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pc5: sai4_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pc10: sai4_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pc11: sai4_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pc12: sai4_d3_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_b_pc12: sai4_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_b_pe0: sai4_mclk_b_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_b_pf6: sai4_sck_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d3_pf10: sai4_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai4_d4_pf10: sai4_d4_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai4_d2_pg8: sai4_d2_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_fs_a_pg8: sai4_fs_a_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck2_pg12: sai4_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sck_a_pg12: sai4_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_ck1_pg13: sai4_ck1_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai4_mclk_a_pg13: sai4_mclk_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai4_d1_pg14: sai4_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai4_sd_a_pg14: sai4_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/n6/stm32n645a0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n645a0hxq-pinctrl.dtsi
@@ -1619,6 +1619,136 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb0: sai1_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb0: sai1_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb6: sai1_sck_a_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb7: sai1_d1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb7: sai1_sd_a_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd2: sai1_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd2: sai1_sd_a_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd12: sai1_d3_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pg2: sai1_fs_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pb3: sai2_fs_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pb7: sai2_mclk_b_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pd10: sai2_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pf5: sai2_sd_a_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg13: sai2_fs_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
@@ -2203,79 +2333,66 @@
 			/omit-if-no-ref/ lpuart1_cts_pa11: lpuart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pf14: usart1_cts_pf14 {
 				pinmux = <STM32_PINMUX('F', 14, AF4)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pf2: usart2_cts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pf5: usart3_cts_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg10: usart3_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF11)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pd3: usart6_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pe10: uart7_cts_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg2: uart7_cts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart9_cts_pd0: uart9_cts_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -2294,80 +2411,67 @@
 
 			/omit-if-no-ref/ usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pf15: usart1_rts_pf15 {
 				pinmux = <STM32_PINMUX('F', 15, AF4)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pf3: usart2_rts_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pg14: usart2_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg2: usart3_rts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg13: usart3_rts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pd4: usart6_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/n6/stm32n645b0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n645b0hxq-pinctrl.dtsi
@@ -2129,6 +2129,148 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb0: sai1_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb0: sai1_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb6: sai1_sck_a_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb7: sai1_d1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb7: sai1_sd_a_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd2: sai1_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd2: sai1_sd_a_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd12: sai1_d3_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pg1: sai1_sck_b_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pg2: sai1_fs_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pg8: sai1_sck_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg12: sai1_mclk_b_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pb3: sai2_fs_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pb7: sai2_mclk_b_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pd10: sai2_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pf5: sai2_sd_a_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg13: sai2_fs_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pc1: sdmmc1_cdir_pc1 {
@@ -3024,97 +3166,81 @@
 			/omit-if-no-ref/ lpuart1_cts_pa11: lpuart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pf14: usart1_cts_pf14 {
 				pinmux = <STM32_PINMUX('F', 14, AF4)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pf2: usart2_cts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pg5: usart2_cts_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pf5: usart3_cts_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg10: usart3_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pg8: uart4_cts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF11)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pd3: usart6_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pe10: uart7_cts_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg2: uart7_cts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pf1: uart8_cts_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart9_cts_pd0: uart9_cts_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -3133,92 +3259,77 @@
 
 			/omit-if-no-ref/ usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pf15: usart1_rts_pf15 {
 				pinmux = <STM32_PINMUX('F', 15, AF4)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pf3: usart2_rts_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pg14: usart2_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg2: usart3_rts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg13: usart3_rts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pd4: usart6_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pg1: uart7_rts_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pf0: uart8_rts_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/n6/stm32n645i0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n645i0hxq-pinctrl.dtsi
@@ -1931,6 +1931,160 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb0: sai1_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb0: sai1_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb6: sai1_sck_a_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb7: sai1_d1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb7: sai1_sd_a_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd2: sai1_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd2: sai1_sd_a_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd12: sai1_d3_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pg1: sai1_sck_b_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pg2: sai1_fs_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pg8: sai1_sck_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg12: sai1_mclk_b_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pb3: sai2_fs_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pb7: sai2_mclk_b_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pd10: sai2_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pf5: sai2_sd_a_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg13: sai2_fs_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pc1: sdmmc1_cdir_pc1 {
@@ -2769,85 +2923,71 @@
 			/omit-if-no-ref/ lpuart1_cts_pa11: lpuart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pf14: usart1_cts_pf14 {
 				pinmux = <STM32_PINMUX('F', 14, AF4)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pf2: usart2_cts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pf5: usart3_cts_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg10: usart3_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pg8: uart4_cts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF11)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pd3: usart6_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pe10: uart7_cts_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg2: uart7_cts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart9_cts_pd0: uart9_cts_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -2866,92 +3006,77 @@
 
 			/omit-if-no-ref/ usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pf15: usart1_rts_pf15 {
 				pinmux = <STM32_PINMUX('F', 15, AF4)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pf3: usart2_rts_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pg14: usart2_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg2: usart3_rts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg13: usart3_rts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pd4: usart6_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pg1: uart7_rts_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/n6/stm32n645l0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n645l0hxq-pinctrl.dtsi
@@ -2374,6 +2374,164 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb0: sai1_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb0: sai1_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb6: sai1_sck_a_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb7: sai1_d1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb7: sai1_sd_a_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd2: sai1_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd2: sai1_sd_a_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd12: sai1_d3_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pg1: sai1_sck_b_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pg2: sai1_fs_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pg8: sai1_sck_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg12: sai1_mclk_b_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pb3: sai2_fs_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pb7: sai2_mclk_b_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pb8: sai2_fs_b_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pd10: sai2_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pf5: sai2_sd_a_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg13: sai2_fs_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pc1: sdmmc1_cdir_pc1 {
@@ -3357,115 +3515,96 @@
 			/omit-if-no-ref/ usart10_cts_pb13: usart10_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ lpuart1_cts_pa11: lpuart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pf14: usart1_cts_pf14 {
 				pinmux = <STM32_PINMUX('F', 14, AF4)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pf2: usart2_cts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pg5: usart2_cts_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pf5: usart3_cts_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg10: usart3_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pg8: uart4_cts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF11)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pb13: usart6_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pb14: usart6_cts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pd3: usart6_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pe10: uart7_cts_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg2: uart7_cts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pf1: uart8_cts_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart9_cts_pd0: uart9_cts_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -3484,104 +3623,87 @@
 
 			/omit-if-no-ref/ usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pf15: usart1_rts_pf15 {
 				pinmux = <STM32_PINMUX('F', 15, AF4)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pf3: usart2_rts_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pg14: usart2_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg2: usart3_rts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg13: usart3_rts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pb15: usart6_rts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pd4: usart6_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pg1: uart7_rts_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pf0: uart8_rts_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/n6/stm32n645x0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n645x0hxq-pinctrl.dtsi
@@ -2565,6 +2565,196 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb0: sai1_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb0: sai1_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb6: sai1_sck_a_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb7: sai1_d1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb7: sai1_sd_a_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc2: sai1_d1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc2: sai1_sck_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd2: sai1_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd2: sai1_sd_a_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd12: sai1_d3_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pg1: sai1_sck_b_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pg2: sai1_fs_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pg8: sai1_sck_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg12: sai1_mclk_b_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pb3: sai2_fs_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pb7: sai2_mclk_b_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pb8: sai2_fs_b_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc5: sai2_sd_b_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pd10: sai2_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pf5: sai2_sd_a_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg13: sai2_fs_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pq2: sai2_sck_b_pq2 {
+				pinmux = <STM32_PINMUX('Q', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pq5: sai2_fs_b_pq5 {
+				pinmux = <STM32_PINMUX('Q', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pq6: sai2_sd_b_pq6 {
+				pinmux = <STM32_PINMUX('Q', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pq7: sai2_mclk_b_pq7 {
+				pinmux = <STM32_PINMUX('Q', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pc1: sdmmc1_cdir_pc1 {
@@ -3688,115 +3878,96 @@
 			/omit-if-no-ref/ usart10_cts_pb13: usart10_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ lpuart1_cts_pa11: lpuart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pf14: usart1_cts_pf14 {
 				pinmux = <STM32_PINMUX('F', 14, AF4)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pf2: usart2_cts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pg5: usart2_cts_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pf5: usart3_cts_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg10: usart3_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pg8: uart4_cts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF11)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pb13: usart6_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pb14: usart6_cts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pd3: usart6_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pe10: uart7_cts_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg2: uart7_cts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pf1: uart8_cts_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart9_cts_pd0: uart9_cts_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -3820,122 +3991,102 @@
 
 			/omit-if-no-ref/ usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pf15: usart1_rts_pf15 {
 				pinmux = <STM32_PINMUX('F', 15, AF4)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pf3: usart2_rts_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pg14: usart2_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc4: usart3_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg2: usart3_rts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg13: usart3_rts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pc4: uart4_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pb15: usart6_rts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pd4: usart6_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe4: usart6_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pg1: uart7_rts_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pf0: uart8_rts_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/n6/stm32n645z0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n645z0hxq-pinctrl.dtsi
@@ -1343,6 +1343,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d2_pb0: sai1_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb0: sai1_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb6: sai1_sck_a_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb7: sai1_d1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb7: sai1_sd_a_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pg2: sai1_fs_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pb7: sai2_mclk_b_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pf5: sai2_sd_a_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg13: sai2_fs_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
@@ -1839,67 +1941,56 @@
 			/omit-if-no-ref/ lpuart1_cts_pa11: lpuart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pf14: usart1_cts_pf14 {
 				pinmux = <STM32_PINMUX('F', 14, AF4)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pf2: usart2_cts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pf5: usart3_cts_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg10: usart3_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF11)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pe10: uart7_cts_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg2: uart7_cts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -1918,74 +2009,62 @@
 
 			/omit-if-no-ref/ usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pf15: usart1_rts_pf15 {
 				pinmux = <STM32_PINMUX('F', 15, AF4)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pf3: usart2_rts_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pg14: usart2_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg2: usart3_rts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg13: usart3_rts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/n6/stm32n647a0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n647a0hxq-pinctrl.dtsi
@@ -1619,6 +1619,136 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb0: sai1_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb0: sai1_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb6: sai1_sck_a_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb7: sai1_d1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb7: sai1_sd_a_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd2: sai1_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd2: sai1_sd_a_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd12: sai1_d3_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pg2: sai1_fs_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pb3: sai2_fs_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pb7: sai2_mclk_b_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pd10: sai2_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pf5: sai2_sd_a_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg13: sai2_fs_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
@@ -2203,79 +2333,66 @@
 			/omit-if-no-ref/ lpuart1_cts_pa11: lpuart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pf14: usart1_cts_pf14 {
 				pinmux = <STM32_PINMUX('F', 14, AF4)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pf2: usart2_cts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pf5: usart3_cts_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg10: usart3_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF11)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pd3: usart6_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pe10: uart7_cts_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg2: uart7_cts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart9_cts_pd0: uart9_cts_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -2294,80 +2411,67 @@
 
 			/omit-if-no-ref/ usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pf15: usart1_rts_pf15 {
 				pinmux = <STM32_PINMUX('F', 15, AF4)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pf3: usart2_rts_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pg14: usart2_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg2: usart3_rts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg13: usart3_rts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pd4: usart6_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/n6/stm32n647b0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n647b0hxq-pinctrl.dtsi
@@ -2129,6 +2129,148 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb0: sai1_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb0: sai1_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb6: sai1_sck_a_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb7: sai1_d1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb7: sai1_sd_a_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd2: sai1_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd2: sai1_sd_a_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd12: sai1_d3_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pg1: sai1_sck_b_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pg2: sai1_fs_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pg8: sai1_sck_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg12: sai1_mclk_b_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pb3: sai2_fs_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pb7: sai2_mclk_b_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pd10: sai2_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pf5: sai2_sd_a_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg13: sai2_fs_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pc1: sdmmc1_cdir_pc1 {
@@ -3024,97 +3166,81 @@
 			/omit-if-no-ref/ lpuart1_cts_pa11: lpuart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pf14: usart1_cts_pf14 {
 				pinmux = <STM32_PINMUX('F', 14, AF4)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pf2: usart2_cts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pg5: usart2_cts_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pf5: usart3_cts_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg10: usart3_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pg8: uart4_cts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF11)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pd3: usart6_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pe10: uart7_cts_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg2: uart7_cts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pf1: uart8_cts_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart9_cts_pd0: uart9_cts_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -3133,92 +3259,77 @@
 
 			/omit-if-no-ref/ usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pf15: usart1_rts_pf15 {
 				pinmux = <STM32_PINMUX('F', 15, AF4)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pf3: usart2_rts_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pg14: usart2_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg2: usart3_rts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg13: usart3_rts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pd4: usart6_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pg1: uart7_rts_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pf0: uart8_rts_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/n6/stm32n647i0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n647i0hxq-pinctrl.dtsi
@@ -1931,6 +1931,160 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb0: sai1_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb0: sai1_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb6: sai1_sck_a_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb7: sai1_d1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb7: sai1_sd_a_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd2: sai1_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd2: sai1_sd_a_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd12: sai1_d3_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pg1: sai1_sck_b_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pg2: sai1_fs_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pg8: sai1_sck_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg12: sai1_mclk_b_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pb3: sai2_fs_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pb7: sai2_mclk_b_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pd10: sai2_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pf5: sai2_sd_a_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg13: sai2_fs_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pc1: sdmmc1_cdir_pc1 {
@@ -2769,85 +2923,71 @@
 			/omit-if-no-ref/ lpuart1_cts_pa11: lpuart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pf14: usart1_cts_pf14 {
 				pinmux = <STM32_PINMUX('F', 14, AF4)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pf2: usart2_cts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pf5: usart3_cts_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg10: usart3_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pg8: uart4_cts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF11)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pd3: usart6_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pe10: uart7_cts_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg2: uart7_cts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart9_cts_pd0: uart9_cts_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -2866,92 +3006,77 @@
 
 			/omit-if-no-ref/ usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pf15: usart1_rts_pf15 {
 				pinmux = <STM32_PINMUX('F', 15, AF4)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pf3: usart2_rts_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pg14: usart2_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg2: usart3_rts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg13: usart3_rts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pd4: usart6_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pg1: uart7_rts_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/n6/stm32n647l0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n647l0hxq-pinctrl.dtsi
@@ -2374,6 +2374,164 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb0: sai1_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb0: sai1_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb6: sai1_sck_a_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb7: sai1_d1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb7: sai1_sd_a_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd2: sai1_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd2: sai1_sd_a_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd12: sai1_d3_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pg1: sai1_sck_b_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pg2: sai1_fs_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pg8: sai1_sck_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg12: sai1_mclk_b_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pb3: sai2_fs_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pb7: sai2_mclk_b_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pb8: sai2_fs_b_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pd10: sai2_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pf5: sai2_sd_a_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg13: sai2_fs_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pc1: sdmmc1_cdir_pc1 {
@@ -3357,115 +3515,96 @@
 			/omit-if-no-ref/ usart10_cts_pb13: usart10_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ lpuart1_cts_pa11: lpuart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pf14: usart1_cts_pf14 {
 				pinmux = <STM32_PINMUX('F', 14, AF4)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pf2: usart2_cts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pg5: usart2_cts_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pf5: usart3_cts_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg10: usart3_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pg8: uart4_cts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF11)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pb13: usart6_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pb14: usart6_cts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pd3: usart6_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pe10: uart7_cts_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg2: uart7_cts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pf1: uart8_cts_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart9_cts_pd0: uart9_cts_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -3484,104 +3623,87 @@
 
 			/omit-if-no-ref/ usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pf15: usart1_rts_pf15 {
 				pinmux = <STM32_PINMUX('F', 15, AF4)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pf3: usart2_rts_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pg14: usart2_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg2: usart3_rts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg13: usart3_rts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pb15: usart6_rts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pd4: usart6_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pg1: uart7_rts_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pf0: uart8_rts_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/n6/stm32n647x0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n647x0hxq-pinctrl.dtsi
@@ -2565,6 +2565,196 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb0: sai1_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb0: sai1_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb6: sai1_sck_a_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb7: sai1_d1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb7: sai1_sd_a_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc2: sai1_d1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc2: sai1_sck_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd2: sai1_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd2: sai1_sd_a_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd12: sai1_d3_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pg1: sai1_sck_b_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pg2: sai1_fs_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pg8: sai1_sck_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg12: sai1_mclk_b_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pb3: sai2_fs_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pb7: sai2_mclk_b_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pb8: sai2_fs_b_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc5: sai2_sd_b_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pd10: sai2_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pf5: sai2_sd_a_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg13: sai2_fs_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pq2: sai2_sck_b_pq2 {
+				pinmux = <STM32_PINMUX('Q', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pq5: sai2_fs_b_pq5 {
+				pinmux = <STM32_PINMUX('Q', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pq6: sai2_sd_b_pq6 {
+				pinmux = <STM32_PINMUX('Q', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pq7: sai2_mclk_b_pq7 {
+				pinmux = <STM32_PINMUX('Q', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pc1: sdmmc1_cdir_pc1 {
@@ -3688,115 +3878,96 @@
 			/omit-if-no-ref/ usart10_cts_pb13: usart10_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ lpuart1_cts_pa11: lpuart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pf14: usart1_cts_pf14 {
 				pinmux = <STM32_PINMUX('F', 14, AF4)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pf2: usart2_cts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pg5: usart2_cts_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pf5: usart3_cts_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg10: usart3_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pg8: uart4_cts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF11)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pb13: usart6_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pb14: usart6_cts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pd3: usart6_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pe10: uart7_cts_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg2: uart7_cts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pf1: uart8_cts_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart9_cts_pd0: uart9_cts_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -3820,122 +3991,102 @@
 
 			/omit-if-no-ref/ usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pf15: usart1_rts_pf15 {
 				pinmux = <STM32_PINMUX('F', 15, AF4)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pf3: usart2_rts_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pg14: usart2_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc4: usart3_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg2: usart3_rts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg13: usart3_rts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pc4: uart4_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pb15: usart6_rts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pd4: usart6_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe4: usart6_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pg1: uart7_rts_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pf0: uart8_rts_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/n6/stm32n647z0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n647z0hxq-pinctrl.dtsi
@@ -1343,6 +1343,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d2_pb0: sai1_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb0: sai1_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb6: sai1_sck_a_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb7: sai1_d1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb7: sai1_sd_a_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pg2: sai1_fs_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pb7: sai2_mclk_b_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pf5: sai2_sd_a_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg13: sai2_fs_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
@@ -1839,67 +1941,56 @@
 			/omit-if-no-ref/ lpuart1_cts_pa11: lpuart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pf14: usart1_cts_pf14 {
 				pinmux = <STM32_PINMUX('F', 14, AF4)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pf2: usart2_cts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pf5: usart3_cts_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg10: usart3_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF11)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pe10: uart7_cts_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg2: uart7_cts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -1918,74 +2009,62 @@
 
 			/omit-if-no-ref/ usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pf15: usart1_rts_pf15 {
 				pinmux = <STM32_PINMUX('F', 15, AF4)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pf3: usart2_rts_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pg14: usart2_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg2: usart3_rts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg13: usart3_rts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/n6/stm32n655a0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n655a0hxq-pinctrl.dtsi
@@ -1619,6 +1619,136 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb0: sai1_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb0: sai1_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb6: sai1_sck_a_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb7: sai1_d1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb7: sai1_sd_a_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd2: sai1_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd2: sai1_sd_a_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd12: sai1_d3_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pg2: sai1_fs_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pb3: sai2_fs_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pb7: sai2_mclk_b_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pd10: sai2_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pf5: sai2_sd_a_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg13: sai2_fs_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
@@ -2203,79 +2333,66 @@
 			/omit-if-no-ref/ lpuart1_cts_pa11: lpuart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pf14: usart1_cts_pf14 {
 				pinmux = <STM32_PINMUX('F', 14, AF4)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pf2: usart2_cts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pf5: usart3_cts_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg10: usart3_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF11)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pd3: usart6_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pe10: uart7_cts_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg2: uart7_cts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart9_cts_pd0: uart9_cts_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -2294,80 +2411,67 @@
 
 			/omit-if-no-ref/ usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pf15: usart1_rts_pf15 {
 				pinmux = <STM32_PINMUX('F', 15, AF4)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pf3: usart2_rts_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pg14: usart2_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg2: usart3_rts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg13: usart3_rts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pd4: usart6_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/n6/stm32n655b0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n655b0hxq-pinctrl.dtsi
@@ -2129,6 +2129,148 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb0: sai1_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb0: sai1_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb6: sai1_sck_a_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb7: sai1_d1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb7: sai1_sd_a_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd2: sai1_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd2: sai1_sd_a_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd12: sai1_d3_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pg1: sai1_sck_b_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pg2: sai1_fs_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pg8: sai1_sck_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg12: sai1_mclk_b_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pb3: sai2_fs_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pb7: sai2_mclk_b_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pd10: sai2_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pf5: sai2_sd_a_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg13: sai2_fs_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pc1: sdmmc1_cdir_pc1 {
@@ -3024,97 +3166,81 @@
 			/omit-if-no-ref/ lpuart1_cts_pa11: lpuart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pf14: usart1_cts_pf14 {
 				pinmux = <STM32_PINMUX('F', 14, AF4)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pf2: usart2_cts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pg5: usart2_cts_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pf5: usart3_cts_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg10: usart3_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pg8: uart4_cts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF11)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pd3: usart6_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pe10: uart7_cts_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg2: uart7_cts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pf1: uart8_cts_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart9_cts_pd0: uart9_cts_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -3133,92 +3259,77 @@
 
 			/omit-if-no-ref/ usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pf15: usart1_rts_pf15 {
 				pinmux = <STM32_PINMUX('F', 15, AF4)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pf3: usart2_rts_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pg14: usart2_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg2: usart3_rts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg13: usart3_rts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pd4: usart6_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pg1: uart7_rts_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pf0: uart8_rts_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/n6/stm32n655i0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n655i0hxq-pinctrl.dtsi
@@ -1931,6 +1931,160 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb0: sai1_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb0: sai1_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb6: sai1_sck_a_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb7: sai1_d1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb7: sai1_sd_a_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd2: sai1_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd2: sai1_sd_a_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd12: sai1_d3_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pg1: sai1_sck_b_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pg2: sai1_fs_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pg8: sai1_sck_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg12: sai1_mclk_b_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pb3: sai2_fs_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pb7: sai2_mclk_b_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pd10: sai2_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pf5: sai2_sd_a_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg13: sai2_fs_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pc1: sdmmc1_cdir_pc1 {
@@ -2769,85 +2923,71 @@
 			/omit-if-no-ref/ lpuart1_cts_pa11: lpuart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pf14: usart1_cts_pf14 {
 				pinmux = <STM32_PINMUX('F', 14, AF4)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pf2: usart2_cts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pf5: usart3_cts_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg10: usart3_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pg8: uart4_cts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF11)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pd3: usart6_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pe10: uart7_cts_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg2: uart7_cts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart9_cts_pd0: uart9_cts_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -2866,92 +3006,77 @@
 
 			/omit-if-no-ref/ usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pf15: usart1_rts_pf15 {
 				pinmux = <STM32_PINMUX('F', 15, AF4)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pf3: usart2_rts_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pg14: usart2_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg2: usart3_rts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg13: usart3_rts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pd4: usart6_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pg1: uart7_rts_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/n6/stm32n655l0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n655l0hxq-pinctrl.dtsi
@@ -2374,6 +2374,164 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb0: sai1_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb0: sai1_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb6: sai1_sck_a_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb7: sai1_d1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb7: sai1_sd_a_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd2: sai1_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd2: sai1_sd_a_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd12: sai1_d3_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pg1: sai1_sck_b_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pg2: sai1_fs_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pg8: sai1_sck_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg12: sai1_mclk_b_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pb3: sai2_fs_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pb7: sai2_mclk_b_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pb8: sai2_fs_b_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pd10: sai2_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pf5: sai2_sd_a_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg13: sai2_fs_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pc1: sdmmc1_cdir_pc1 {
@@ -3357,115 +3515,96 @@
 			/omit-if-no-ref/ usart10_cts_pb13: usart10_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ lpuart1_cts_pa11: lpuart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pf14: usart1_cts_pf14 {
 				pinmux = <STM32_PINMUX('F', 14, AF4)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pf2: usart2_cts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pg5: usart2_cts_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pf5: usart3_cts_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg10: usart3_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pg8: uart4_cts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF11)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pb13: usart6_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pb14: usart6_cts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pd3: usart6_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pe10: uart7_cts_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg2: uart7_cts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pf1: uart8_cts_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart9_cts_pd0: uart9_cts_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -3484,104 +3623,87 @@
 
 			/omit-if-no-ref/ usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pf15: usart1_rts_pf15 {
 				pinmux = <STM32_PINMUX('F', 15, AF4)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pf3: usart2_rts_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pg14: usart2_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg2: usart3_rts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg13: usart3_rts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pb15: usart6_rts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pd4: usart6_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pg1: uart7_rts_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pf0: uart8_rts_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/n6/stm32n655x0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n655x0hxq-pinctrl.dtsi
@@ -2565,6 +2565,196 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb0: sai1_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb0: sai1_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb6: sai1_sck_a_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb7: sai1_d1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb7: sai1_sd_a_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc2: sai1_d1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc2: sai1_sck_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd2: sai1_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd2: sai1_sd_a_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd12: sai1_d3_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pg1: sai1_sck_b_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pg2: sai1_fs_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pg8: sai1_sck_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg12: sai1_mclk_b_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pb3: sai2_fs_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pb7: sai2_mclk_b_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pb8: sai2_fs_b_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc5: sai2_sd_b_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pd10: sai2_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pf5: sai2_sd_a_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg13: sai2_fs_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pq2: sai2_sck_b_pq2 {
+				pinmux = <STM32_PINMUX('Q', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pq5: sai2_fs_b_pq5 {
+				pinmux = <STM32_PINMUX('Q', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pq6: sai2_sd_b_pq6 {
+				pinmux = <STM32_PINMUX('Q', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pq7: sai2_mclk_b_pq7 {
+				pinmux = <STM32_PINMUX('Q', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pc1: sdmmc1_cdir_pc1 {
@@ -3688,115 +3878,96 @@
 			/omit-if-no-ref/ usart10_cts_pb13: usart10_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ lpuart1_cts_pa11: lpuart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pf14: usart1_cts_pf14 {
 				pinmux = <STM32_PINMUX('F', 14, AF4)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pf2: usart2_cts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pg5: usart2_cts_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pf5: usart3_cts_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg10: usart3_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pg8: uart4_cts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF11)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pb13: usart6_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pb14: usart6_cts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pd3: usart6_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pe10: uart7_cts_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg2: uart7_cts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pf1: uart8_cts_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart9_cts_pd0: uart9_cts_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -3820,122 +3991,102 @@
 
 			/omit-if-no-ref/ usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pf15: usart1_rts_pf15 {
 				pinmux = <STM32_PINMUX('F', 15, AF4)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pf3: usart2_rts_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pg14: usart2_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc4: usart3_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg2: usart3_rts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg13: usart3_rts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pc4: uart4_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pb15: usart6_rts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pd4: usart6_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe4: usart6_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pg1: uart7_rts_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pf0: uart8_rts_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/n6/stm32n655z0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n655z0hxq-pinctrl.dtsi
@@ -1343,6 +1343,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d2_pb0: sai1_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb0: sai1_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb6: sai1_sck_a_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb7: sai1_d1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb7: sai1_sd_a_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pg2: sai1_fs_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pb7: sai2_mclk_b_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pf5: sai2_sd_a_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg13: sai2_fs_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
@@ -1839,67 +1941,56 @@
 			/omit-if-no-ref/ lpuart1_cts_pa11: lpuart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pf14: usart1_cts_pf14 {
 				pinmux = <STM32_PINMUX('F', 14, AF4)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pf2: usart2_cts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pf5: usart3_cts_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg10: usart3_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF11)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pe10: uart7_cts_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg2: uart7_cts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -1918,74 +2009,62 @@
 
 			/omit-if-no-ref/ usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pf15: usart1_rts_pf15 {
 				pinmux = <STM32_PINMUX('F', 15, AF4)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pf3: usart2_rts_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pg14: usart2_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg2: usart3_rts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg13: usart3_rts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/n6/stm32n657a0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n657a0hxq-pinctrl.dtsi
@@ -1619,6 +1619,136 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb0: sai1_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb0: sai1_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb6: sai1_sck_a_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb7: sai1_d1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb7: sai1_sd_a_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd2: sai1_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd2: sai1_sd_a_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd12: sai1_d3_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pg2: sai1_fs_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pb3: sai2_fs_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pb7: sai2_mclk_b_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pd10: sai2_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pf5: sai2_sd_a_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg13: sai2_fs_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
@@ -2203,79 +2333,66 @@
 			/omit-if-no-ref/ lpuart1_cts_pa11: lpuart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pf14: usart1_cts_pf14 {
 				pinmux = <STM32_PINMUX('F', 14, AF4)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pf2: usart2_cts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pf5: usart3_cts_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg10: usart3_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF11)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pd3: usart6_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pe10: uart7_cts_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg2: uart7_cts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart9_cts_pd0: uart9_cts_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -2294,80 +2411,67 @@
 
 			/omit-if-no-ref/ usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pf15: usart1_rts_pf15 {
 				pinmux = <STM32_PINMUX('F', 15, AF4)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pf3: usart2_rts_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pg14: usart2_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg2: usart3_rts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg13: usart3_rts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pd4: usart6_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/n6/stm32n657b0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n657b0hxq-pinctrl.dtsi
@@ -2129,6 +2129,148 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb0: sai1_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb0: sai1_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb6: sai1_sck_a_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb7: sai1_d1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb7: sai1_sd_a_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd2: sai1_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd2: sai1_sd_a_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd12: sai1_d3_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pg1: sai1_sck_b_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pg2: sai1_fs_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pg8: sai1_sck_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg12: sai1_mclk_b_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pb3: sai2_fs_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pb7: sai2_mclk_b_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pd10: sai2_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pf5: sai2_sd_a_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg13: sai2_fs_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pc1: sdmmc1_cdir_pc1 {
@@ -3024,97 +3166,81 @@
 			/omit-if-no-ref/ lpuart1_cts_pa11: lpuart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pf14: usart1_cts_pf14 {
 				pinmux = <STM32_PINMUX('F', 14, AF4)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pf2: usart2_cts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pg5: usart2_cts_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pf5: usart3_cts_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg10: usart3_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pg8: uart4_cts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF11)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pd3: usart6_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pe10: uart7_cts_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg2: uart7_cts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pf1: uart8_cts_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart9_cts_pd0: uart9_cts_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -3133,92 +3259,77 @@
 
 			/omit-if-no-ref/ usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pf15: usart1_rts_pf15 {
 				pinmux = <STM32_PINMUX('F', 15, AF4)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pf3: usart2_rts_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pg14: usart2_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg2: usart3_rts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg13: usart3_rts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pd4: usart6_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pg1: uart7_rts_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pf0: uart8_rts_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/n6/stm32n657i0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n657i0hxq-pinctrl.dtsi
@@ -1931,6 +1931,160 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb0: sai1_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb0: sai1_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb6: sai1_sck_a_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb7: sai1_d1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb7: sai1_sd_a_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd2: sai1_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd2: sai1_sd_a_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd12: sai1_d3_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pg1: sai1_sck_b_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pg2: sai1_fs_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pg8: sai1_sck_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg12: sai1_mclk_b_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pb3: sai2_fs_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pb7: sai2_mclk_b_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pd10: sai2_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pf5: sai2_sd_a_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg13: sai2_fs_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pc1: sdmmc1_cdir_pc1 {
@@ -2769,85 +2923,71 @@
 			/omit-if-no-ref/ lpuart1_cts_pa11: lpuart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pf14: usart1_cts_pf14 {
 				pinmux = <STM32_PINMUX('F', 14, AF4)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pf2: usart2_cts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pf5: usart3_cts_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg10: usart3_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pg8: uart4_cts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF11)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pd3: usart6_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pe10: uart7_cts_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg2: uart7_cts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart9_cts_pd0: uart9_cts_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -2866,92 +3006,77 @@
 
 			/omit-if-no-ref/ usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pf15: usart1_rts_pf15 {
 				pinmux = <STM32_PINMUX('F', 15, AF4)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pf3: usart2_rts_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pg14: usart2_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg2: usart3_rts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg13: usart3_rts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pd4: usart6_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pg1: uart7_rts_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/n6/stm32n657l0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n657l0hxq-pinctrl.dtsi
@@ -2374,6 +2374,164 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb0: sai1_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb0: sai1_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb6: sai1_sck_a_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb7: sai1_d1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb7: sai1_sd_a_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd2: sai1_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd2: sai1_sd_a_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd12: sai1_d3_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pg1: sai1_sck_b_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pg2: sai1_fs_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pg8: sai1_sck_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg12: sai1_mclk_b_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pb3: sai2_fs_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pb7: sai2_mclk_b_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pb8: sai2_fs_b_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pd10: sai2_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pf5: sai2_sd_a_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg13: sai2_fs_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pc1: sdmmc1_cdir_pc1 {
@@ -3357,115 +3515,96 @@
 			/omit-if-no-ref/ usart10_cts_pb13: usart10_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ lpuart1_cts_pa11: lpuart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pf14: usart1_cts_pf14 {
 				pinmux = <STM32_PINMUX('F', 14, AF4)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pf2: usart2_cts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pg5: usart2_cts_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pf5: usart3_cts_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg10: usart3_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pg8: uart4_cts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF11)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pb13: usart6_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pb14: usart6_cts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pd3: usart6_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pe10: uart7_cts_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg2: uart7_cts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pf1: uart8_cts_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart9_cts_pd0: uart9_cts_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -3484,104 +3623,87 @@
 
 			/omit-if-no-ref/ usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pf15: usart1_rts_pf15 {
 				pinmux = <STM32_PINMUX('F', 15, AF4)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pf3: usart2_rts_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pg14: usart2_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg2: usart3_rts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg13: usart3_rts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pb15: usart6_rts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pd4: usart6_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pg1: uart7_rts_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pf0: uart8_rts_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/n6/stm32n657x0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n657x0hxq-pinctrl.dtsi
@@ -2565,6 +2565,196 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa3: sai1_sd_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb0: sai1_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb0: sai1_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb6: sai1_sck_a_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb7: sai1_d1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb7: sai1_sd_a_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc2: sai1_d1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc2: sai1_sck_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd2: sai1_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd2: sai1_sd_a_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd12: sai1_d3_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pg1: sai1_sck_b_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pg2: sai1_fs_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pg8: sai1_sck_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg12: sai1_mclk_b_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pb3: sai2_fs_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pb7: sai2_mclk_b_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pb8: sai2_fs_b_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc5: sai2_sd_b_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pd10: sai2_fs_b_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd13: sai2_sck_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe11: sai2_sd_b_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pf5: sai2_sd_a_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg13: sai2_fs_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pq2: sai2_sck_b_pq2 {
+				pinmux = <STM32_PINMUX('Q', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pq5: sai2_fs_b_pq5 {
+				pinmux = <STM32_PINMUX('Q', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pq6: sai2_sd_b_pq6 {
+				pinmux = <STM32_PINMUX('Q', 6, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pq7: sai2_mclk_b_pq7 {
+				pinmux = <STM32_PINMUX('Q', 7, AF10)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_cdir_pc1: sdmmc1_cdir_pc1 {
@@ -3688,115 +3878,96 @@
 			/omit-if-no-ref/ usart10_cts_pb13: usart10_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ lpuart1_cts_pa11: lpuart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pf14: usart1_cts_pf14 {
 				pinmux = <STM32_PINMUX('F', 14, AF4)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pf2: usart2_cts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pg5: usart2_cts_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pf5: usart3_cts_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg10: usart3_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pg8: uart4_cts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF11)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pb13: usart6_cts_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pb14: usart6_cts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pd3: usart6_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pe10: uart7_cts_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg2: uart7_cts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pf1: uart8_cts_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart9_cts_pd0: uart9_cts_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -3820,122 +3991,102 @@
 
 			/omit-if-no-ref/ usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pf15: usart1_rts_pf15 {
 				pinmux = <STM32_PINMUX('F', 15, AF4)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pf3: usart2_rts_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pg14: usart2_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc4: usart3_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg2: usart3_rts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg13: usart3_rts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pc4: uart4_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pb15: usart6_rts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pd4: usart6_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe4: usart6_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pg1: uart7_rts_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pf0: uart8_rts_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/n6/stm32n657z0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n657z0hxq-pinctrl.dtsi
@@ -1343,6 +1343,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_d2_pb0: sai1_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb0: sai1_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb6: sai1_sck_a_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb7: sai1_d1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb7: sai1_sd_a_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pg2: sai1_fs_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pa0: sai2_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pa1: sai2_mclk_b_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pa2: sai2_sck_b_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa12: sai2_fs_b_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pb7: sai2_mclk_b_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pe0: sai2_mclk_a_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pe7: sai2_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe12: sai2_sck_b_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pe13: sai2_fs_b_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pe14: sai2_mclk_b_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pf5: sai2_sd_a_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pf11: sai2_sd_b_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg13: sai2_fs_a_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF10)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
@@ -1839,67 +1941,56 @@
 			/omit-if-no-ref/ lpuart1_cts_pa11: lpuart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pf14: usart1_cts_pf14 {
 				pinmux = <STM32_PINMUX('F', 14, AF4)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pf2: usart2_cts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pf5: usart3_cts_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg10: usart3_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF11)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pe10: uart7_cts_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg2: uart7_cts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -1918,74 +2009,62 @@
 
 			/omit-if-no-ref/ usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pf15: usart1_rts_pf15 {
 				pinmux = <STM32_PINMUX('F', 15, AF4)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pf3: usart2_rts_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pg14: usart2_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg2: usart3_rts_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg13: usart3_rts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/u5/stm32u535cbtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535cbtx-pinctrl.dtsi
@@ -475,6 +475,84 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u535cbtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535cbtxq-pinctrl.dtsi
@@ -408,6 +408,72 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u535cbux-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535cbux-pinctrl.dtsi
@@ -475,6 +475,84 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u535cbuxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535cbuxq-pinctrl.dtsi
@@ -408,6 +408,72 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u535cctx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535cctx-pinctrl.dtsi
@@ -475,6 +475,84 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u535cctxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535cctxq-pinctrl.dtsi
@@ -408,6 +408,72 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u535ccux-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535ccux-pinctrl.dtsi
@@ -475,6 +475,84 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u535ccuxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535ccuxq-pinctrl.dtsi
@@ -408,6 +408,72 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u535cetx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535cetx-pinctrl.dtsi
@@ -475,6 +475,84 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u535cetxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535cetxq-pinctrl.dtsi
@@ -408,6 +408,72 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u535ceux-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535ceux-pinctrl.dtsi
@@ -475,6 +475,84 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u535ceuxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535ceuxq-pinctrl.dtsi
@@ -408,6 +408,72 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u535jeyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535jeyxq-pinctrl.dtsi
@@ -595,6 +595,88 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u535ncyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535ncyxq-pinctrl.dtsi
@@ -471,6 +471,100 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u535neyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535neyxq-pinctrl.dtsi
@@ -471,6 +471,100 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u535rbix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535rbix-pinctrl.dtsi
@@ -621,6 +621,100 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u535rbixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535rbixq-pinctrl.dtsi
@@ -564,6 +564,88 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u535rbtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535rbtx-pinctrl.dtsi
@@ -621,6 +621,100 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u535rbtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535rbtxq-pinctrl.dtsi
@@ -564,6 +564,88 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u535rcix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535rcix-pinctrl.dtsi
@@ -621,6 +621,100 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u535rcixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535rcixq-pinctrl.dtsi
@@ -564,6 +564,88 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u535rctx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535rctx-pinctrl.dtsi
@@ -621,6 +621,100 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u535rctxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535rctxq-pinctrl.dtsi
@@ -564,6 +564,88 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u535reix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535reix-pinctrl.dtsi
@@ -621,6 +621,100 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u535reixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535reixq-pinctrl.dtsi
@@ -564,6 +564,88 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u535retx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535retx-pinctrl.dtsi
@@ -621,6 +621,100 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u535retxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535retxq-pinctrl.dtsi
@@ -564,6 +564,88 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u535vcix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535vcix-pinctrl.dtsi
@@ -959,6 +959,160 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u535vcixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535vcixq-pinctrl.dtsi
@@ -928,6 +928,156 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u535vctx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535vctx-pinctrl.dtsi
@@ -959,6 +959,160 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u535vctxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535vctxq-pinctrl.dtsi
@@ -928,6 +928,156 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u535veix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535veix-pinctrl.dtsi
@@ -959,6 +959,160 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u535veixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535veixq-pinctrl.dtsi
@@ -928,6 +928,156 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u535vetx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535vetx-pinctrl.dtsi
@@ -959,6 +959,160 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u535vetxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535vetxq-pinctrl.dtsi
@@ -928,6 +928,156 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u545cetx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545cetx-pinctrl.dtsi
@@ -475,6 +475,84 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u545cetxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545cetxq-pinctrl.dtsi
@@ -408,6 +408,72 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u545ceux-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545ceux-pinctrl.dtsi
@@ -475,6 +475,84 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u545ceuxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545ceuxq-pinctrl.dtsi
@@ -408,6 +408,72 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u545jeyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545jeyxq-pinctrl.dtsi
@@ -595,6 +595,88 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u545neyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545neyxq-pinctrl.dtsi
@@ -471,6 +471,100 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u545reix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545reix-pinctrl.dtsi
@@ -621,6 +621,100 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u545reixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545reixq-pinctrl.dtsi
@@ -564,6 +564,88 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u545retx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545retx-pinctrl.dtsi
@@ -621,6 +621,100 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u545retxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545retxq-pinctrl.dtsi
@@ -564,6 +564,88 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u545veix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545veix-pinctrl.dtsi
@@ -959,6 +959,160 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u545veixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545veixq-pinctrl.dtsi
@@ -928,6 +928,156 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u545vetx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545vetx-pinctrl.dtsi
@@ -959,6 +959,160 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u545vetxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545vetxq-pinctrl.dtsi
@@ -928,6 +928,156 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575agix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575agix-pinctrl.dtsi
@@ -1925,6 +1925,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575agixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575agixq-pinctrl.dtsi
@@ -1884,6 +1884,276 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575aiix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575aiix-pinctrl.dtsi
@@ -1925,6 +1925,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575aiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575aiixq-pinctrl.dtsi
@@ -1884,6 +1884,276 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575cgtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575cgtx-pinctrl.dtsi
@@ -475,6 +475,84 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u575cgtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575cgtxq-pinctrl.dtsi
@@ -408,6 +408,72 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u575cgux-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575cgux-pinctrl.dtsi
@@ -475,6 +475,84 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u575cguxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575cguxq-pinctrl.dtsi
@@ -408,6 +408,72 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u575citx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575citx-pinctrl.dtsi
@@ -475,6 +475,84 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u575citxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575citxq-pinctrl.dtsi
@@ -408,6 +408,72 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u575ciux-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ciux-pinctrl.dtsi
@@ -475,6 +475,84 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u575ciuxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ciuxq-pinctrl.dtsi
@@ -408,6 +408,72 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u575ogyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ogyxq-pinctrl.dtsi
@@ -956,6 +956,144 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575oiyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575oiyxq-pinctrl.dtsi
@@ -956,6 +956,144 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575qgix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575qgix-pinctrl.dtsi
@@ -1601,6 +1601,260 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575qgixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575qgixq-pinctrl.dtsi
@@ -1546,6 +1546,256 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575qiix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575qiix-pinctrl.dtsi
@@ -1601,6 +1601,260 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575qiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575qiixq-pinctrl.dtsi
@@ -1546,6 +1546,256 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575rgtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575rgtx-pinctrl.dtsi
@@ -693,6 +693,100 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575rgtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575rgtxq-pinctrl.dtsi
@@ -564,6 +564,88 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575ritx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ritx-pinctrl.dtsi
@@ -693,6 +693,100 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575ritxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ritxq-pinctrl.dtsi
@@ -564,6 +564,88 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575vgtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575vgtx-pinctrl.dtsi
@@ -1165,6 +1165,220 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575vgtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575vgtxq-pinctrl.dtsi
@@ -1128,6 +1128,212 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575vitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575vitx-pinctrl.dtsi
@@ -1165,6 +1165,220 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575vitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575vitxq-pinctrl.dtsi
@@ -1128,6 +1128,212 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575zgtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575zgtx-pinctrl.dtsi
@@ -1638,6 +1638,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575zgtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575zgtxq-pinctrl.dtsi
@@ -1607,6 +1607,268 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575zitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575zitx-pinctrl.dtsi
@@ -1638,6 +1638,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575zitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575zitxq-pinctrl.dtsi
@@ -1607,6 +1607,268 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u585aiix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585aiix-pinctrl.dtsi
@@ -1925,6 +1925,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u585aiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585aiixq-pinctrl.dtsi
@@ -1884,6 +1884,276 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u585citx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585citx-pinctrl.dtsi
@@ -475,6 +475,84 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u585citxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585citxq-pinctrl.dtsi
@@ -408,6 +408,72 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u585ciux-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585ciux-pinctrl.dtsi
@@ -475,6 +475,84 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u585ciuxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585ciuxq-pinctrl.dtsi
@@ -408,6 +408,72 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u585oiyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585oiyxq-pinctrl.dtsi
@@ -956,6 +956,144 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u585qiix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585qiix-pinctrl.dtsi
@@ -1601,6 +1601,260 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u585qiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585qiixq-pinctrl.dtsi
@@ -1546,6 +1546,256 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u585ritx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585ritx-pinctrl.dtsi
@@ -693,6 +693,100 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u585ritxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585ritxq-pinctrl.dtsi
@@ -564,6 +564,88 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u585vitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585vitx-pinctrl.dtsi
@@ -1165,6 +1165,220 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u585vitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585vitxq-pinctrl.dtsi
@@ -1128,6 +1128,212 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u585zitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585zitx-pinctrl.dtsi
@@ -1638,6 +1638,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u585zitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585zitxq-pinctrl.dtsi
@@ -1607,6 +1607,268 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u595aihx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595aihx-pinctrl.dtsi
@@ -2071,6 +2071,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u595aihxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595aihxq-pinctrl.dtsi
@@ -2030,6 +2030,276 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u595ajhx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595ajhx-pinctrl.dtsi
@@ -2071,6 +2071,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u595ajhxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595ajhxq-pinctrl.dtsi
@@ -2030,6 +2030,276 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u595qiix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595qiix-pinctrl.dtsi
@@ -1730,6 +1730,260 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u595qiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595qiixq-pinctrl.dtsi
@@ -1675,6 +1675,256 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u595qjix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595qjix-pinctrl.dtsi
@@ -1730,6 +1730,260 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u595qjixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595qjixq-pinctrl.dtsi
@@ -1675,6 +1675,256 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u595ritx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595ritx-pinctrl.dtsi
@@ -761,6 +761,100 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u595ritxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595ritxq-pinctrl.dtsi
@@ -624,6 +624,88 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u595rjtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595rjtx-pinctrl.dtsi
@@ -761,6 +761,100 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u595rjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595rjtxq-pinctrl.dtsi
@@ -624,6 +624,88 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u595vitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595vitx-pinctrl.dtsi
@@ -1282,6 +1282,220 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u595vitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595vitxq-pinctrl.dtsi
@@ -1227,6 +1227,212 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u595vjtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595vjtx-pinctrl.dtsi
@@ -1282,6 +1282,220 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u595vjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595vjtxq-pinctrl.dtsi
@@ -1227,6 +1227,212 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u595zitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595zitx-pinctrl.dtsi
@@ -1767,6 +1767,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u595zitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595zitxq-pinctrl.dtsi
@@ -1718,6 +1718,268 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u595ziyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595ziyxq-pinctrl.dtsi
@@ -1788,6 +1788,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u595zjtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595zjtx-pinctrl.dtsi
@@ -1767,6 +1767,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u595zjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595zjtxq-pinctrl.dtsi
@@ -1718,6 +1718,268 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u595zjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595zjyxq-pinctrl.dtsi
@@ -1788,6 +1788,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u599bjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599bjyxq-pinctrl.dtsi
@@ -2274,6 +2274,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u599nihxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599nihxq-pinctrl.dtsi
@@ -2347,6 +2347,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u599njhxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599njhxq-pinctrl.dtsi
@@ -2347,6 +2347,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u599vitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599vitxq-pinctrl.dtsi
@@ -1353,6 +1353,212 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u599vjtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599vjtx-pinctrl.dtsi
@@ -1412,6 +1412,220 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u599vjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599vjtxq-pinctrl.dtsi
@@ -1353,6 +1353,212 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u599zitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599zitxq-pinctrl.dtsi
@@ -1880,6 +1880,268 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u599ziyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599ziyxq-pinctrl.dtsi
@@ -1836,6 +1836,264 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u599zjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599zjtxq-pinctrl.dtsi
@@ -1880,6 +1880,268 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u599zjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599zjyxq-pinctrl.dtsi
@@ -1836,6 +1836,264 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u5a5ajhx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5ajhx-pinctrl.dtsi
@@ -2071,6 +2071,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u5a5ajhxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5ajhxq-pinctrl.dtsi
@@ -2030,6 +2030,276 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u5a5qiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5qiixq-pinctrl.dtsi
@@ -1675,6 +1675,256 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u5a5qjix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5qjix-pinctrl.dtsi
@@ -1730,6 +1730,260 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u5a5qjixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5qjixq-pinctrl.dtsi
@@ -1675,6 +1675,256 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u5a5rjtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5rjtx-pinctrl.dtsi
@@ -761,6 +761,100 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u5a5rjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5rjtxq-pinctrl.dtsi
@@ -624,6 +624,88 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u5a5vjtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5vjtx-pinctrl.dtsi
@@ -1282,6 +1282,220 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u5a5vjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5vjtxq-pinctrl.dtsi
@@ -1227,6 +1227,212 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u5a5zjtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5zjtx-pinctrl.dtsi
@@ -1767,6 +1767,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u5a5zjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5zjtxq-pinctrl.dtsi
@@ -1718,6 +1718,268 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u5a5zjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5zjyxq-pinctrl.dtsi
@@ -1788,6 +1788,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u5a9bjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a9bjyxq-pinctrl.dtsi
@@ -2274,6 +2274,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u5a9njhxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a9njhxq-pinctrl.dtsi
@@ -2347,6 +2347,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u5a9vjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a9vjtxq-pinctrl.dtsi
@@ -1353,6 +1353,212 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u5a9zjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a9zjtxq-pinctrl.dtsi
@@ -1880,6 +1880,268 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u5a9zjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a9zjyxq-pinctrl.dtsi
@@ -1836,6 +1836,264 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u5f7vitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f7vitx-pinctrl.dtsi
@@ -1402,6 +1402,220 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u5f7vitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f7vitxq-pinctrl.dtsi
@@ -1343,6 +1343,212 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u5f7vjtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f7vjtx-pinctrl.dtsi
@@ -1402,6 +1402,220 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u5f7vjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f7vjtxq-pinctrl.dtsi
@@ -1343,6 +1343,212 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u5f9bjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9bjyxq-pinctrl.dtsi
@@ -2248,6 +2248,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u5f9njhxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9njhxq-pinctrl.dtsi
@@ -2321,6 +2321,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u5f9vitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9vitxq-pinctrl.dtsi
@@ -968,6 +968,140 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {

--- a/dts/st/u5/stm32u5f9vjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9vjtxq-pinctrl.dtsi
@@ -968,6 +968,140 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {

--- a/dts/st/u5/stm32u5f9zijxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9zijxq-pinctrl.dtsi
@@ -1679,6 +1679,224 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u5f9zitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9zitxq-pinctrl.dtsi
@@ -1679,6 +1679,224 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u5f9zjjxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9zjjxq-pinctrl.dtsi
@@ -1679,6 +1679,224 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u5f9zjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9zjtxq-pinctrl.dtsi
@@ -1679,6 +1679,224 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u5g7vjtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g7vjtx-pinctrl.dtsi
@@ -1430,6 +1430,220 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u5g7vjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g7vjtxq-pinctrl.dtsi
@@ -1371,6 +1371,212 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u5g9bjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g9bjyxq-pinctrl.dtsi
@@ -2248,6 +2248,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u5g9njhxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g9njhxq-pinctrl.dtsi
@@ -2365,6 +2365,280 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pf6: sai1_sd_b_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf7: sai1_mclk_b_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pf9: sai1_fs_b_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pg7: sai1_ck1_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pg7: sai1_mclk_a_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb12: sai2_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pg2: sai2_sck_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pg3: sai2_fs_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg4: sai2_mclk_b_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg5: sai2_sd_b_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pg11: sai2_mclk_a_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u5g9vjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g9vjtxq-pinctrl.dtsi
@@ -1004,6 +1004,140 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {

--- a/dts/st/u5/stm32u5g9zjjxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g9zjjxq-pinctrl.dtsi
@@ -1715,6 +1715,224 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u5g9zjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g9zjtxq-pinctrl.dtsi
@@ -1715,6 +1715,224 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc1: sai1_sd_a_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe3: sai1_sd_b_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pe5: sai1_ck2_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pe5: sai1_sck_a_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pe6: sai1_d1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pe6: sai1_sd_a_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pe7: sai1_sd_b_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe8: sai1_sck_b_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe9: sai1_fs_b_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pe10: sai1_mclk_b_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pa15: sai2_fs_b_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb13: sai2_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb14: sai2_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pb15: sai2_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pc0: sai2_fs_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc6: sai2_mclk_a_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc7: sai2_mclk_b_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc10: sai2_sck_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc11: sai2_mclk_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pd9: sai2_mclk_a_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pd10: sai2_sck_a_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pd11: sai2_sd_a_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pd12: sai2_fs_a_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg9: sai2_sck_a_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg10: sai2_fs_a_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg12: sai2_sd_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF13)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/wb/stm32wb35c(c-e)uxa-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb35c(c-e)uxa-pinctrl.dtsi
@@ -319,6 +319,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa5: sai1_sd_b_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pa9: sai1_d2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb2: sai1_extclk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/wb/stm32wb55ccux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55ccux-pinctrl.dtsi
@@ -319,6 +319,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa5: sai1_sd_b_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pa9: sai1_d2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb2: sai1_extclk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/wb/stm32wb55ceux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55ceux-pinctrl.dtsi
@@ -319,6 +319,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa5: sai1_sd_b_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pa9: sai1_d2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb2: sai1_extclk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/wb/stm32wb55cgux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55cgux-pinctrl.dtsi
@@ -319,6 +319,96 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa5: sai1_sd_b_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pa9: sai1_d2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb2: sai1_extclk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/wb/stm32wb55rcvx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55rcvx-pinctrl.dtsi
@@ -470,6 +470,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa5: sai1_sd_b_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pa9: sai1_d2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb2: sai1_extclk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/wb/stm32wb55revx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55revx-pinctrl.dtsi
@@ -470,6 +470,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa5: sai1_sd_b_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pa9: sai1_d2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb2: sai1_extclk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/wb/stm32wb55rgvx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55rgvx-pinctrl.dtsi
@@ -470,6 +470,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa5: sai1_sd_b_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pa9: sai1_d2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb2: sai1_extclk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/wb/stm32wb55vcqx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vcqx-pinctrl.dtsi
@@ -587,6 +587,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa5: sai1_sd_b_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pa9: sai1_d2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb2: sai1_extclk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pc9: sai1_sck_b_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pd5: sai1_mclk_b_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/wb/stm32wb55vcyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vcyx-pinctrl.dtsi
@@ -587,6 +587,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa5: sai1_sd_b_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pa9: sai1_d2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb2: sai1_extclk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pc9: sai1_sck_b_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pd5: sai1_mclk_b_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/wb/stm32wb55veqx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55veqx-pinctrl.dtsi
@@ -587,6 +587,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa5: sai1_sd_b_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pa9: sai1_d2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb2: sai1_extclk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pc9: sai1_sck_b_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pd5: sai1_mclk_b_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/wb/stm32wb55veyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55veyx-pinctrl.dtsi
@@ -587,6 +587,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa5: sai1_sd_b_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pa9: sai1_d2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb2: sai1_extclk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pc9: sai1_sck_b_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pd5: sai1_mclk_b_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/wb/stm32wb55vgqx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vgqx-pinctrl.dtsi
@@ -587,6 +587,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa5: sai1_sd_b_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pa9: sai1_d2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb2: sai1_extclk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pc9: sai1_sck_b_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pd5: sai1_mclk_b_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/wb/stm32wb55vgyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vgyx-pinctrl.dtsi
@@ -587,6 +587,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa5: sai1_sd_b_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pa9: sai1_d2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb2: sai1_extclk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pc9: sai1_sck_b_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pd5: sai1_mclk_b_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/wb/stm32wb55vyyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vyyx-pinctrl.dtsi
@@ -587,6 +587,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa5: sai1_sd_b_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pa9: sai1_d2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb2: sai1_extclk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pc9: sai1_sck_b_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pd5: sai1_mclk_b_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/wb/stm32wb5mmghx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb5mmghx-pinctrl.dtsi
@@ -574,6 +574,152 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_extclk_pa0: sai1_extclk_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa3: sai1_ck1_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa3: sai1_mclk_a_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa4: sai1_fs_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa5: sai1_sd_b_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa8: sai1_ck2_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa8: sai1_sck_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pa9: sai1_d2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa9: sai1_fs_a_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa10: sai1_sd_a_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pa13: sai1_sd_b_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa14: sai1_fs_b_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_extclk_pb2: sai1_extclk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb3: sai1_sck_b_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb5: sai1_sd_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb6: sai1_fs_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pb8: sai1_ck1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb8: sai1_mclk_a_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb9: sai1_d2_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb10: sai1_sck_a_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pb12: sai1_fs_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pb13: sai1_sck_a_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pb14: sai1_mclk_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb15: sai1_sd_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pc3: sai1_d1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pc3: sai1_sd_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc5: sai1_d3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pc9: sai1_sck_b_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pd5: sai1_mclk_b_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pe2: sai1_ck1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pe2: sai1_mclk_a_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/wba/stm32wba54ceux-pinctrl.dtsi
+++ b/dts/st/wba/stm32wba54ceux-pinctrl.dtsi
@@ -283,6 +283,72 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa1: sai1_ck1_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa2: sai1_d1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pa5: sai1_d2_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa6: sai1_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa6: sai1_mclk_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa7: sai1_sck_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa8: sai1_fs_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa9: sai1_ck1_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb5: sai1_d2_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb5: sai1_fs_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb6: sai1_sck_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb7: sai1_sd_b_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb12: sai1_sd_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb14: sai1_sd_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pb3: spi1_miso_pb3 {

--- a/dts/st/wba/stm32wba54cgux-pinctrl.dtsi
+++ b/dts/st/wba/stm32wba54cgux-pinctrl.dtsi
@@ -283,6 +283,72 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa1: sai1_ck1_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa2: sai1_d1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pa5: sai1_d2_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa6: sai1_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa6: sai1_mclk_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa7: sai1_sck_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa8: sai1_fs_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa9: sai1_ck1_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb5: sai1_d2_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb5: sai1_fs_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb6: sai1_sck_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb7: sai1_sd_b_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb12: sai1_sd_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb14: sai1_sd_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pb3: spi1_miso_pb3 {

--- a/dts/st/wba/stm32wba54keux-pinctrl.dtsi
+++ b/dts/st/wba/stm32wba54keux-pinctrl.dtsi
@@ -195,6 +195,44 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa1: sai1_ck1_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa2: sai1_d1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pa5: sai1_d2_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa6: sai1_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa6: sai1_mclk_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa7: sai1_sck_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa8: sai1_fs_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb12: sai1_sd_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pb3: spi1_miso_pb3 {

--- a/dts/st/wba/stm32wba54kgux-pinctrl.dtsi
+++ b/dts/st/wba/stm32wba54kgux-pinctrl.dtsi
@@ -195,6 +195,44 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa1: sai1_ck1_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa2: sai1_d1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pa5: sai1_d2_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa6: sai1_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa6: sai1_mclk_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa7: sai1_sck_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa8: sai1_fs_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb12: sai1_sd_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pb3: spi1_miso_pb3 {

--- a/dts/st/wba/stm32wba55ceux-pinctrl.dtsi
+++ b/dts/st/wba/stm32wba55ceux-pinctrl.dtsi
@@ -263,6 +263,72 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa1: sai1_ck1_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa2: sai1_d1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pa5: sai1_d2_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa6: sai1_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa6: sai1_mclk_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa7: sai1_sck_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa8: sai1_fs_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa9: sai1_ck1_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb5: sai1_d2_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb5: sai1_fs_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb6: sai1_sck_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb7: sai1_sd_b_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb12: sai1_sd_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb14: sai1_sd_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pb3: spi1_miso_pb3 {

--- a/dts/st/wba/stm32wba55cgux-pinctrl.dtsi
+++ b/dts/st/wba/stm32wba55cgux-pinctrl.dtsi
@@ -263,6 +263,72 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa1: sai1_ck1_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa2: sai1_d1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pa5: sai1_d2_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa6: sai1_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa6: sai1_mclk_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa7: sai1_sck_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa8: sai1_fs_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa9: sai1_ck1_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb5: sai1_d2_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb5: sai1_fs_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb6: sai1_sck_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb7: sai1_sd_b_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb12: sai1_sd_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb14: sai1_sd_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pb3: spi1_miso_pb3 {

--- a/dts/st/wba/stm32wba55hefx-pinctrl.dtsi
+++ b/dts/st/wba/stm32wba55hefx-pinctrl.dtsi
@@ -283,6 +283,72 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa1: sai1_ck1_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa2: sai1_d1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pa5: sai1_d2_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa6: sai1_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa6: sai1_mclk_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa7: sai1_sck_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa8: sai1_fs_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa9: sai1_ck1_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb5: sai1_d2_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb5: sai1_fs_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb6: sai1_sck_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb7: sai1_sd_b_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb12: sai1_sd_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb14: sai1_sd_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pb3: spi1_miso_pb3 {

--- a/dts/st/wba/stm32wba55hgfx-pinctrl.dtsi
+++ b/dts/st/wba/stm32wba55hgfx-pinctrl.dtsi
@@ -283,6 +283,72 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa1: sai1_ck1_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa2: sai1_d1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pa5: sai1_d2_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa6: sai1_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa6: sai1_mclk_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa7: sai1_sck_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa8: sai1_fs_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa9: sai1_ck1_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb5: sai1_d2_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb5: sai1_fs_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb6: sai1_sck_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb7: sai1_sd_b_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb12: sai1_sd_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb14: sai1_sd_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pb3: spi1_miso_pb3 {

--- a/dts/st/wba/stm32wba55ueix-pinctrl.dtsi
+++ b/dts/st/wba/stm32wba55ueix-pinctrl.dtsi
@@ -287,6 +287,72 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa1: sai1_ck1_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa2: sai1_d1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pa5: sai1_d2_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa6: sai1_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa6: sai1_mclk_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa7: sai1_sck_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa8: sai1_fs_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa9: sai1_ck1_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb5: sai1_d2_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb5: sai1_fs_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb6: sai1_sck_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb7: sai1_sd_b_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb12: sai1_sd_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb14: sai1_sd_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pb3: spi1_miso_pb3 {

--- a/dts/st/wba/stm32wba55ugix-pinctrl.dtsi
+++ b/dts/st/wba/stm32wba55ugix-pinctrl.dtsi
@@ -287,6 +287,72 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa1: sai1_ck1_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa2: sai1_d1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pa5: sai1_d2_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa6: sai1_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa6: sai1_mclk_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa7: sai1_sck_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa8: sai1_fs_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa9: sai1_ck1_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb5: sai1_d2_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb5: sai1_fs_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb6: sai1_sck_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb7: sai1_sd_b_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb12: sai1_sd_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb14: sai1_sd_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pb3: spi1_miso_pb3 {

--- a/dts/st/wba/stm32wba5mjghx-pinctrl.dtsi
+++ b/dts/st/wba/stm32wba5mjghx-pinctrl.dtsi
@@ -279,6 +279,72 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_ck1_pa1: sai1_ck1_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa2: sai1_d1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pa5: sai1_d2_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pa6: sai1_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pa6: sai1_mclk_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa7: sai1_sck_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pa8: sai1_fs_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pa9: sai1_ck1_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pb4: sai1_mclk_b_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pb5: sai1_d2_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pb5: sai1_fs_b_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pb6: sai1_sck_b_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pb7: sai1_sd_b_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb12: sai1_sd_a_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb14: sai1_sd_a_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pb3: spi1_miso_pb3 {

--- a/scripts/genpinctrl/stm32-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32-pinctrl-config.yaml
@@ -226,6 +226,9 @@
   match: "^XSPIM(.*)(?:CLK|NCS[1-2]|DQS[0-1]|IO\\d+)$"
   slew-rate: very-high-speed
 
+- name: SAI
+  match: "^SAI\\d+_(?:D\\d+)?(?:CK\\d+)?(?:FS_A)?(?:FS_B)?(?:MCLK_A)?(?:MCLK_B)?(?:SD_A)?(?:SD_B)?(?:SCK_A)?(?:SCK_B)?(?:EXTCLK)?$"
+
 - name: SDMMC
   match: "^SDMMC\\d+_(?:CK)?(?:CKIN)?(?:CDIR)?(?:CMD)?(?:D\\d+)?(?:D0DIR)?(?:D123DIR)?$"
   slew-rate: very-high-speed


### PR DESCRIPTION
Added SAI pinctrl nodes
I am planning on writing an SAI I2S driver in zephyr so I need these nodes to be defined.
I'm not sure how to see if I should add more properties (pull-up, push-pull...). So LMK if I'm making some mistake.

BTW, I'm getting the following warnings when running the genpinctrl script:
```
Unexpected AF format: GPIO_AF2_rf (ip: STM32WL33_gpio_v1_0)                                                                                                                                                 
Skipping unsupported family STM32MP2.                                                                                                                                                                       
Skipping unsupported family STM32U3.                                                                  
Skipping unsupported family STM32WL3.
```