### PR TITLE
STM32N6 Ethernet : Add missing rgmii pinctrl 

### DIFF
--- a/dts/st/n6/stm32n645a0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n645a0hxq-pinctrl.dtsi
@@ -747,6 +747,11 @@
 
 			/* ETH_RGMII */
 
+			/omit-if-no-ref/ eth1_rgmii_clk125_pf2: eth1_rgmii_clk125_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth1_rgmii_rx_clk_pf7: eth1_rgmii_rx_clk_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF11)>;
 				slew-rate = "very-high-speed";
@@ -759,6 +764,11 @@
 
 			/omit-if-no-ref/ eth1_rgmii_rx_ctl_pf10: eth1_rgmii_rx_ctl_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rgmii_tx_ctl_pf11: eth1_rgmii_tx_ctl_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/n6/stm32n645b0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n645b0hxq-pinctrl.dtsi
@@ -1030,6 +1030,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth1_rgmii_clk125_pf2: eth1_rgmii_clk125_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth1_rgmii_rx_clk_pf7: eth1_rgmii_rx_clk_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF11)>;
 				slew-rate = "very-high-speed";
@@ -1047,6 +1052,11 @@
 
 			/omit-if-no-ref/ eth1_rgmii_rx_ctl_pf10: eth1_rgmii_rx_ctl_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rgmii_tx_ctl_pf11: eth1_rgmii_tx_ctl_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/n6/stm32n645i0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n645i0hxq-pinctrl.dtsi
@@ -895,6 +895,11 @@
 
 			/* ETH_RGMII */
 
+			/omit-if-no-ref/ eth1_rgmii_clk125_pf2: eth1_rgmii_clk125_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth1_rgmii_rx_clk_pf7: eth1_rgmii_rx_clk_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF11)>;
 				slew-rate = "very-high-speed";
@@ -907,6 +912,11 @@
 
 			/omit-if-no-ref/ eth1_rgmii_rx_ctl_pf10: eth1_rgmii_rx_ctl_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rgmii_tx_ctl_pf11: eth1_rgmii_tx_ctl_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/n6/stm32n645l0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n645l0hxq-pinctrl.dtsi
@@ -1122,6 +1122,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth1_rgmii_clk125_pf2: eth1_rgmii_clk125_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth1_rgmii_rx_clk_pf7: eth1_rgmii_rx_clk_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF11)>;
 				slew-rate = "very-high-speed";
@@ -1139,6 +1144,11 @@
 
 			/omit-if-no-ref/ eth1_rgmii_rx_ctl_pf10: eth1_rgmii_rx_ctl_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rgmii_tx_ctl_pf11: eth1_rgmii_tx_ctl_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/n6/stm32n645x0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n645x0hxq-pinctrl.dtsi
@@ -1236,6 +1236,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth1_rgmii_clk125_pf2: eth1_rgmii_clk125_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth1_rgmii_rx_clk_pf7: eth1_rgmii_rx_clk_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF11)>;
 				slew-rate = "very-high-speed";
@@ -1253,6 +1258,11 @@
 
 			/omit-if-no-ref/ eth1_rgmii_rx_ctl_pf10: eth1_rgmii_rx_ctl_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rgmii_tx_ctl_pf11: eth1_rgmii_tx_ctl_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/n6/stm32n647a0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n647a0hxq-pinctrl.dtsi
@@ -747,6 +747,11 @@
 
 			/* ETH_RGMII */
 
+			/omit-if-no-ref/ eth1_rgmii_clk125_pf2: eth1_rgmii_clk125_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth1_rgmii_rx_clk_pf7: eth1_rgmii_rx_clk_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF11)>;
 				slew-rate = "very-high-speed";
@@ -759,6 +764,11 @@
 
 			/omit-if-no-ref/ eth1_rgmii_rx_ctl_pf10: eth1_rgmii_rx_ctl_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rgmii_tx_ctl_pf11: eth1_rgmii_tx_ctl_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/n6/stm32n647b0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n647b0hxq-pinctrl.dtsi
@@ -1030,6 +1030,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth1_rgmii_clk125_pf2: eth1_rgmii_clk125_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth1_rgmii_rx_clk_pf7: eth1_rgmii_rx_clk_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF11)>;
 				slew-rate = "very-high-speed";
@@ -1047,6 +1052,11 @@
 
 			/omit-if-no-ref/ eth1_rgmii_rx_ctl_pf10: eth1_rgmii_rx_ctl_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rgmii_tx_ctl_pf11: eth1_rgmii_tx_ctl_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/n6/stm32n647l0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n647l0hxq-pinctrl.dtsi
@@ -1122,6 +1122,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth1_rgmii_clk125_pf2: eth1_rgmii_clk125_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth1_rgmii_rx_clk_pf7: eth1_rgmii_rx_clk_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF11)>;
 				slew-rate = "very-high-speed";
@@ -1139,6 +1144,11 @@
 
 			/omit-if-no-ref/ eth1_rgmii_rx_ctl_pf10: eth1_rgmii_rx_ctl_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rgmii_tx_ctl_pf11: eth1_rgmii_tx_ctl_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/n6/stm32n647x0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n647x0hxq-pinctrl.dtsi
@@ -1236,6 +1236,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth1_rgmii_clk125_pf2: eth1_rgmii_clk125_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth1_rgmii_rx_clk_pf7: eth1_rgmii_rx_clk_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF11)>;
 				slew-rate = "very-high-speed";
@@ -1253,6 +1258,11 @@
 
 			/omit-if-no-ref/ eth1_rgmii_rx_ctl_pf10: eth1_rgmii_rx_ctl_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rgmii_tx_ctl_pf11: eth1_rgmii_tx_ctl_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/n6/stm32n655a0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n655a0hxq-pinctrl.dtsi
@@ -747,6 +747,11 @@
 
 			/* ETH_RGMII */
 
+			/omit-if-no-ref/ eth1_rgmii_gtx_clk_pf0: eth1_rgmii_gtx_clk_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth1_rgmii_rx_clk_pf7: eth1_rgmii_rx_clk_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF11)>;
 				slew-rate = "very-high-speed";
@@ -759,6 +764,11 @@
 
 			/omit-if-no-ref/ eth1_rgmii_rx_ctl_pf10: eth1_rgmii_rx_ctl_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rgmii_tx_ctl_pf11: eth1_rgmii_tx_ctl_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/n6/stm32n655b0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n655b0hxq-pinctrl.dtsi
@@ -1030,6 +1030,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth1_rgmii_clk125_pf2: eth1_rgmii_clk125_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth1_rgmii_rx_clk_pf7: eth1_rgmii_rx_clk_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF11)>;
 				slew-rate = "very-high-speed";
@@ -1047,6 +1052,11 @@
 
 			/omit-if-no-ref/ eth1_rgmii_rx_ctl_pf10: eth1_rgmii_rx_ctl_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rgmii_tx_ctl_pf11: eth1_rgmii_tx_ctl_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/n6/stm32n655i0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n655i0hxq-pinctrl.dtsi
@@ -895,6 +895,11 @@
 
 			/* ETH_RGMII */
 
+			/omit-if-no-ref/ eth1_rgmii_clk125_pf2: eth1_rgmii_clk125_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth1_rgmii_rx_clk_pf7: eth1_rgmii_rx_clk_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF11)>;
 				slew-rate = "very-high-speed";
@@ -907,6 +912,11 @@
 
 			/omit-if-no-ref/ eth1_rgmii_rx_ctl_pf10: eth1_rgmii_rx_ctl_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rgmii_tx_ctl_pf11: eth1_rgmii_tx_ctl_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/n6/stm32n655l0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n655l0hxq-pinctrl.dtsi
@@ -1122,6 +1122,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth1_rgmii_clk125_pf2: eth1_rgmii_clk125_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth1_rgmii_rx_clk_pf7: eth1_rgmii_rx_clk_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF11)>;
 				slew-rate = "very-high-speed";
@@ -1139,6 +1144,11 @@
 
 			/omit-if-no-ref/ eth1_rgmii_rx_ctl_pf10: eth1_rgmii_rx_ctl_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rgmii_tx_ctl_pf11: eth1_rgmii_tx_ctl_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/n6/stm32n655x0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n655x0hxq-pinctrl.dtsi
@@ -1236,6 +1236,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth1_rgmii_clk125_pf2: eth1_rgmii_clk125_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth1_rgmii_rx_clk_pf7: eth1_rgmii_rx_clk_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF11)>;
 				slew-rate = "very-high-speed";
@@ -1253,6 +1258,11 @@
 
 			/omit-if-no-ref/ eth1_rgmii_rx_ctl_pf10: eth1_rgmii_rx_ctl_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rgmii_tx_ctl_pf11: eth1_rgmii_tx_ctl_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/n6/stm32n657a0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n657a0hxq-pinctrl.dtsi
@@ -747,6 +747,11 @@
 
 			/* ETH_RGMII */
 
+			/omit-if-no-ref/ eth1_rgmii_clk125_pf2: eth1_rgmii_clk125_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth1_rgmii_rx_clk_pf7: eth1_rgmii_rx_clk_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF11)>;
 				slew-rate = "very-high-speed";
@@ -759,6 +764,11 @@
 
 			/omit-if-no-ref/ eth1_rgmii_rx_ctl_pf10: eth1_rgmii_rx_ctl_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rgmii_tx_ctl_pf11: eth1_rgmii_tx_ctl_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/n6/stm32n657b0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n657b0hxq-pinctrl.dtsi
@@ -1030,6 +1030,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth1_rgmii_clk125_pf2: eth1_rgmii_clk125_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth1_rgmii_rx_clk_pf7: eth1_rgmii_rx_clk_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF11)>;
 				slew-rate = "very-high-speed";
@@ -1047,6 +1052,11 @@
 
 			/omit-if-no-ref/ eth1_rgmii_rx_ctl_pf10: eth1_rgmii_rx_ctl_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rgmii_tx_ctl_pf11: eth1_rgmii_tx_ctl_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/n6/stm32n657i0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n657i0hxq-pinctrl.dtsi
@@ -895,6 +895,11 @@
 
 			/* ETH_RGMII */
 
+			/omit-if-no-ref/ eth1_rgmii_clk125_pf2: eth1_rgmii_clk125_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth1_rgmii_rx_clk_pf7: eth1_rgmii_rx_clk_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF11)>;
 				slew-rate = "very-high-speed";
@@ -907,6 +912,11 @@
 
 			/omit-if-no-ref/ eth1_rgmii_rx_ctl_pf10: eth1_rgmii_rx_ctl_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rgmii_tx_ctl_pf11: eth1_rgmii_tx_ctl_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/n6/stm32n657l0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n657l0hxq-pinctrl.dtsi
@@ -1122,6 +1122,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth1_rgmii_clk125_pf2: eth1_rgmii_clk125_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth1_rgmii_rx_clk_pf7: eth1_rgmii_rx_clk_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF11)>;
 				slew-rate = "very-high-speed";
@@ -1139,6 +1144,11 @@
 
 			/omit-if-no-ref/ eth1_rgmii_rx_ctl_pf10: eth1_rgmii_rx_ctl_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rgmii_tx_ctl_pf11: eth1_rgmii_tx_ctl_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/n6/stm32n657x0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n657x0hxq-pinctrl.dtsi
@@ -1236,6 +1236,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth1_rgmii_clk125_pf2: eth1_rgmii_clk125_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth1_rgmii_rx_clk_pf7: eth1_rgmii_rx_clk_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF11)>;
 				slew-rate = "very-high-speed";
@@ -1253,6 +1258,11 @@
 
 			/omit-if-no-ref/ eth1_rgmii_rx_ctl_pf10: eth1_rgmii_rx_ctl_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rgmii_tx_ctl_pf11: eth1_rgmii_tx_ctl_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/scripts/genpinctrl/stm32-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32-pinctrl-config.yaml
@@ -77,7 +77,7 @@
   slew-rate: very-high-speed
 
 - name: ETH_RGMII
-  match: "^ETH\\d+_RGMII_(?:CLk125|GTX_CLK|RXD[0-3]|RX_CLK|RX_CTL|RX_ER|TX_EN|RX_DV|TXD[0-3]|TX_CLK|TX_EN)$"
+  match: "^ETH\\d+_RGMII_(?:CLK125|GTX_CLK|RXD[0-3]|RX_CLK|RX_CTL|RX_ER|TX_EN|RX_DV|TXD[0-3]|TX_CTL|TX_EN)$"
   slew-rate: very-high-speed
 
 - name: ETH_RMII


### PR DESCRIPTION
Correct pinctrl config of the ethernet RGMII
Add missing pinctrl ETH1_RGMII_TX_CTL and ETH1_RGMII_CLK125
