### PR TITLE
lib: stm32wba: Remove support of Nucleo WBA52CG board

### DIFF
--- a/lib/stm32wba/CMakeLists.txt
+++ b/lib/stm32wba/CMakeLists.txt
@@ -2,10 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-if(DEFINED CONFIG_BOARD_NUCLEO_WBA52CG)
-  message(FATAL_ERROR "BLE library is not compatible with nucleo_wba52cg")
-endif()
-
 zephyr_compile_definitions( -DBLE )
 
 zephyr_include_directories(BLE_TransparentMode/Core/Inc)


### PR DESCRIPTION
Remove the check of Nucleo WBA52CG in the CMakeList and remove its support in Zephyr.