### PR TITLE
scripts: stm32cube: genpinctrl for  debug_njtrst pinout

### DIFF
--- a/scripts/genpinctrl/stm32-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32-pinctrl-config.yaml
@@ -144,7 +144,7 @@
   slew-rate: very-high-speed
 
 - name: JTAG PORT
-  match: ^(SYS|DEBUG)_((JTMS-)?SWDIO|(JTCK-)?SWCLK|JTDI|JTDO(-TRACESWO|-SWO)?|(NJ)?JTRST)$
+  match: ^(SYS|DEBUG)_((JTMS-)?SWDIO|(JTCK-)?SWCLK|JTDI|JTDO(-TRACESWO|-SWO)?|(N)?JTRST)$
 
 - name: LTDC
   match: "^LTDC_(?:DE|CLK|HSYNC|VSYNC|R[0-7]|G[0-7]|B[0-7])$"


### PR DESCRIPTION
Generates the debug_njtrst_pb4 pin for the stm32wba65x serie where the PB4(NJRST) is named "DEBUG_NJTRST"


from **STM32WBA65RIVx.xml**
```
    <Pin Name="PB4(NJRST)" Position="32" Type="I/O">
        <Signal Name="DEBUG_NJTRST"/>
```

to **stm32wba65rivx-pinctrl.dtsi**
```
			/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
				pinmux = <STM32_PINMUX('B', 4, AF0)>;
			};
```