### PR TITLE
lib: stm32wb0: Call appropriate Zephyr function for using TRNG peripheral

### DIFF
--- a/lib/stm32wb0/BLE_TransparentMode/STM32_BLE/Target/bleplat.c
+++ b/lib/stm32wb0/BLE_TransparentMode/STM32_BLE/Target/bleplat.c
@@ -118,16 +118,6 @@ int32_t BLEPLAT_AesCMACEncryptFinish(BLEPLAT_AESCMACctxTypeDef *pAESCMACctx,
 }
 #endif /* (BLESTACK_CONTROLLER_ONLY == 0) */
 
-void BLEPLAT_RngGetRandom16(uint16_t* num)
-{
-  HW_RNG_GetRandom16(num);
-}
-
-void BLEPLAT_RngGetRandom32(uint32_t* num)
-{
-  HW_RNG_GetRandom32(num);
-}
-
 uint8_t BLEPLAT_DBmToPALevel(int8_t TX_dBm)
 {
   return RADIO_DBmToPALevel(TX_dBm);

--- a/lib/stm32wb0/README.rst
+++ b/lib/stm32wb0/README.rst
@@ -127,5 +127,7 @@ Patch List:
 	  Impacted file: app_conf.h
 	- Exclude HAL_UART_MspInit and HAL_UART_MspDeInit from compilation:
 	  Impacted file: stm32wb0x_hal_msp.c
+	- Removed BLEPLAT_RngGetRandom16 and BLEPLAT_RngGetRandom32 functions:
+	  Impacted file: bleplat.c
 	- dos2unix applied
 	- trailing white spaces removed


### PR DESCRIPTION
Call appropriate Zephyr function for using TRNG peripheral with BLE library.

Modify README to include the new changes.

Supplementary [PR#90018](https://github.com/zephyrproject-rtos/zephyr/pull/90018)