### PR TITLE
stm32c0xx: Enable HAL PCD module

### DIFF
--- a/stm32cube/stm32c0xx/drivers/include/stm32c0xx_hal_conf.h
+++ b/stm32cube/stm32c0xx/drivers/include/stm32c0xx_hal_conf.h
@@ -45,6 +45,7 @@ extern "C" {
 #define HAL_I2S_MODULE_ENABLED
 #define HAL_IRDA_MODULE_ENABLED
 #define HAL_IWDG_MODULE_ENABLED
+#define HAL_PCD_MODULE_ENABLED
 #define HAL_PWR_MODULE_ENABLED
 #define HAL_RCC_MODULE_ENABLED
 #define HAL_RTC_MODULE_ENABLED
@@ -257,6 +258,10 @@ in voltage and temperature.*/
 #ifdef HAL_WWDG_MODULE_ENABLED
 #include "stm32c0xx_hal_wwdg.h"
 #endif /* HAL_WWDG_MODULE_ENABLED */
+
+#ifdef HAL_PCD_MODULE_ENABLED
+#include "stm32c0xx_hal_pcd.h"
+#endif /* HAL_PCD_MODULE_ENABLED */
 
 /* Exported macro ------------------------------------------------------------*/
 #ifdef  USE_FULL_ASSERT


### PR DESCRIPTION
- Added definition for HAL_PCD_MODULE_ENABLED.
- Included stm32cxx_hal_pcd.h when HAL_PCD_MODULE_ENABLED is defined.