### PR TITLE
stm32cube: stm32h7rs: SMPS is de facto supported

### DIFF
--- a/stm32cube/stm32h7rsxx/README
+++ b/stm32cube/stm32h7rsxx/README
@@ -44,10 +44,6 @@ Patch List:
     -Added stm32cube/stm32h7rsxx/drivers/include/stm32_assert.h
     -Removed unused stm32cube/stm32h7rsxx/drivers/include/stm32_assert_template.h
 
-   *configure the SMPS on the stm32h7s7 so that power config is possible
-    on the stm32h7s78 disco kit
-    -internal ticket 175303
-
    *Fix to remove PAGESIZE definition which conflicts with POSIX
     Impacted files:
      drivers/include/Legacy/stm32_hal_legacy.h

--- a/stm32cube/stm32h7rsxx/soc/stm32h7s7xx.h
+++ b/stm32cube/stm32h7rsxx/soc/stm32h7s7xx.h
@@ -219,8 +219,6 @@ typedef enum
 /* ================                           Processor and Core Peripheral Section                           ================ */
 /* =========================================================================================================================== */
 
-#define SMPS       /*!< Switched mode power supply feature */
-
 /**
   * @brief Configuration of the Cortex-M7 Processor and Core Peripherals
    */


### PR DESCRIPTION
All SoCs of this series support SMPS, so defning this symbol, as it is done on stm32h7 series is not required.