### PR TITLE
scripts: genpinctrl: add support for 14-bit DCMI

### DIFF
--- a/scripts/genpinctrl/stm32-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32-pinctrl-config.yaml
@@ -56,7 +56,7 @@
   match: "^DAC(?:\\d+)?_OUT\\d+$"
 
 - name: DCMI
-  match: "^DCMI_(?:HSYNC|PIXCLK|VSYNC|D[0-7])$"
+  match: "^DCMI_(?:HSYNC|PIXCLK|VSYNC|D[0-9]|D[1][0-3])$"
   slew-rate: very-high-speed
 
 - name: DFSDM


### PR DESCRIPTION
Add support for pins DCMI_D[9-13], to enable 10-, 12-, and 14-bit DCMI.